### PR TITLE
Explore 태그 별 음원 목록 보여주는 기능, 음원 상세 화면 이동

### DIFF
--- a/JipJung/JipJung.xcodeproj/project.pbxproj
+++ b/JipJung/JipJung.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		91EA47C6273846A800780C3E /* BlurCircleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91EA47C5273846A800780C3E /* BlurCircleButton.swift */; };
 		B4015CD42739151B006BD14A /* RecentMusicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4015CD32739151B006BD14A /* RecentMusicViewController.swift */; };
 		B4015CD627391529006BD14A /* FavoriteMusicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4015CD527391529006BD14A /* FavoriteMusicViewController.swift */; };
-		B4015CD82739270C006BD14A /* GenreCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4015CD72739270C006BD14A /* GenreCollectionViewCell.swift */; };
+		B4015CD82739270C006BD14A /* SoundTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4015CD72739270C006BD14A /* SoundTagCollectionViewCell.swift */; };
 		B40D1FA9273B5F1900881A49 /* DefaultFocusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D1FA8273B5F1900881A49 /* DefaultFocusViewController.swift */; };
 		B40D1FAB273B5F2100881A49 /* DefaultFocusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D1FAA273B5F2100881A49 /* DefaultFocusViewModel.swift */; };
 		B40D1FAD273B5F2800881A49 /* PomodoroFocusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D1FAC273B5F2700881A49 /* PomodoroFocusViewController.swift */; };
@@ -60,6 +60,7 @@
 		B4EF13B52742933F0086D8CD /* SearchHistoryUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EF13B42742933F0086D8CD /* SearchHistoryUseCase.swift */; };
 		B4EF13B72742935B0086D8CD /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EF13B62742935B0086D8CD /* SearchViewModel.swift */; };
 		B4EF13B927429A0F0086D8CD /* SearchMediaUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EF13B827429A0F0086D8CD /* SearchMediaUseCase.swift */; };
+		B4EF13BB274370060086D8CD /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EF13BA274370060086D8CD /* String+Extension.swift */; };
 		B4F36B5127336EE20073609C /* UserDefaultsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F36B5027336EE20073609C /* UserDefaultsStorage.swift */; };
 		B4F36B5927338E9B0073609C /* UserDefaultsStorageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F36B5827338E9B0073609C /* UserDefaultsStorageTest.swift */; };
 		B4F36B662733B8770073609C /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F36B652733B8770073609C /* SearchViewController.swift */; };
@@ -157,7 +158,7 @@
 		91EA47C5273846A800780C3E /* BlurCircleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurCircleButton.swift; sourceTree = "<group>"; };
 		B4015CD32739151B006BD14A /* RecentMusicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentMusicViewController.swift; sourceTree = "<group>"; };
 		B4015CD527391529006BD14A /* FavoriteMusicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteMusicViewController.swift; sourceTree = "<group>"; };
-		B4015CD72739270C006BD14A /* GenreCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreCollectionViewCell.swift; sourceTree = "<group>"; };
+		B4015CD72739270C006BD14A /* SoundTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		B40D1FA8273B5F1900881A49 /* DefaultFocusViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultFocusViewController.swift; sourceTree = "<group>"; };
 		B40D1FAA273B5F2100881A49 /* DefaultFocusViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultFocusViewModel.swift; sourceTree = "<group>"; };
 		B40D1FAC273B5F2700881A49 /* PomodoroFocusViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PomodoroFocusViewController.swift; sourceTree = "<group>"; };
@@ -177,6 +178,7 @@
 		B4EF13B42742933F0086D8CD /* SearchHistoryUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistoryUseCase.swift; sourceTree = "<group>"; };
 		B4EF13B62742935B0086D8CD /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		B4EF13B827429A0F0086D8CD /* SearchMediaUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMediaUseCase.swift; sourceTree = "<group>"; };
+		B4EF13BA274370060086D8CD /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		B4F36B5027336EE20073609C /* UserDefaultsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStorage.swift; sourceTree = "<group>"; };
 		B4F36B5627338E9B0073609C /* UserDefaultsStorageTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UserDefaultsStorageTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4F36B5827338E9B0073609C /* UserDefaultsStorageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStorageTest.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 				B42226CD2741144200F8CA3D /* UITableView+Extension.swift */,
 				B42226CB2741134100F8CA3D /* UICollectionView+Extension.swift */,
 				DD4D030427425610007AA4DD /* UILabel+Extension.swift */,
+				B4EF13BA274370060086D8CD /* String+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -370,7 +373,7 @@
 				DDB5CEA127328EC300E8F9EB /* ExploreViewController.swift */,
 				B4F36B652733B8770073609C /* SearchViewController.swift */,
 				B4F36B672733D4200073609C /* SearchTableViewCell.swift */,
-				B4015CD72739270C006BD14A /* GenreCollectionViewCell.swift */,
+				B4015CD72739270C006BD14A /* SoundTagCollectionViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -946,6 +949,7 @@
 				DF08B1DD2737F5010066518B /* RemoteServiceProvider.swift in Sources */,
 				B4F36B682733D4210073609C /* SearchTableViewCell.swift in Sources */,
 				B4EF13B927429A0F0086D8CD /* SearchMediaUseCase.swift in Sources */,
+				B4EF13BB274370060086D8CD /* String+Extension.swift in Sources */,
 				B40D1FB9273B674F00881A49 /* InfinityFocusViewController.swift in Sources */,
 				DDB92B9D2737BD5E00EE26F0 /* UIView+Extension.swift in Sources */,
 				B40D1FA9273B5F1900881A49 /* DefaultFocusViewController.swift in Sources */,
@@ -1029,7 +1033,7 @@
 				91E4178927312FEB001BA0A6 /* LocalFileManager.swift in Sources */,
 				91CE6F7327390AD200176AF2 /* FocusButton.swift in Sources */,
 				B4153941273B93B0004EF80F /* SaveFocusTimeUseCase.swift in Sources */,
-				B4015CD82739270C006BD14A /* GenreCollectionViewCell.swift in Sources */,
+				B4015CD82739270C006BD14A /* SoundTagCollectionViewCell.swift in Sources */,
 				9198DE952733863500EBAEC8 /* Common.swift in Sources */,
 				DF1722B22740FD2300F06140 /* ApplicationLaunch.swift in Sources */,
 				91CE6F7527391E1C00176AF2 /* HomeViewModel.swift in Sources */,

--- a/JipJung/JipJung/Application/SceneDelegate.swift
+++ b/JipJung/JipJung/Application/SceneDelegate.swift
@@ -60,7 +60,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             tag: 1
         )
         
-        let exploreViewController = ExploreViewController()
+        let exploreViewController = ExploreViewController(viewModel: ExploreViewModel(searchMediaUseCase: SearchMediaUseCase()))
         exploreViewController.tabBarItem = tabBarItem
         let exploreNavigationViewController = UINavigationController(rootViewController: exploreViewController)
         

--- a/JipJung/JipJung/Domain/UseCases/SearchMediaUseCase.swift
+++ b/JipJung/JipJung/Domain/UseCases/SearchMediaUseCase.swift
@@ -37,8 +37,7 @@ final class SearchMediaUseCase {
             guard let self = self else { return }
             var searchResult: [Media] = []
             $0.forEach { media in
-                let tagInfo = media.tag.components(separatedBy: "/")
-                if tagInfo.contains(tag) {
+                if media.tag.contains(tag) {
                     searchResult.append(media)
                 }
             }

--- a/JipJung/JipJung/Domain/UseCases/SearchMediaUseCase.swift
+++ b/JipJung/JipJung/Domain/UseCases/SearchMediaUseCase.swift
@@ -32,6 +32,23 @@ final class SearchMediaUseCase {
         fetchAllMediaList()
     }
     
+    func search(tag: String) {
+        allMediaList.bind { [weak self] in
+            guard let self = self else { return }
+            var searchResult: [Media] = []
+            $0.forEach { media in
+                let tagInfo = media.tag.components(separatedBy: "/")
+                if tagInfo.contains(tag) {
+                    searchResult.append(media)
+                }
+            }
+            self.searchResult.accept(searchResult)
+        }
+        .disposed(by: disposeBag)
+        
+        fetchAllMediaList()
+    }
+    
     private func fetchAllMediaList() {
         mediaListRepository.fetchAllMediaList()
             .subscribe { [weak self] in

--- a/JipJung/JipJung/Localizing/Common.swift
+++ b/JipJung/JipJung/Localizing/Common.swift
@@ -27,7 +27,7 @@ enum UserDefaultsKeys {
     static let wasLaunchedBefore = "WasLaunchedBefore"
 }
 
-enum SoundTag {
+enum SoundTag: CaseIterable {
     case all
     case nature
     case urban

--- a/JipJung/JipJung/Localizing/Common.swift
+++ b/JipJung/JipJung/Localizing/Common.swift
@@ -27,15 +27,34 @@ enum UserDefaultsKeys {
     static let wasLaunchedBefore = "WasLaunchedBefore"
 }
 
-enum Genre {
-    static let All = "All"
-    static let Melody = "Melody"
-    static let Nature = "Nature"
-    static let Urban = "Urban"
-    static let Relax = "Relax"
-    static let Techno = "Techno"
-    static let House = "House"
-    static let Hiphop = "Hiphop"
-    static let Jazz = "Jazz"
-    static let Disco = "Disco"
+enum SoundTag {
+    case all
+    case nature
+    case urban
+    case relax
+    case focus
+    case cafe
+    case lounge
+    case club
+    
+    var value: String {
+        switch self {
+        case .all:
+            return "All"
+        case .nature:
+            return "Nature"
+        case .urban:
+            return "Urban"
+        case .relax:
+            return "Relax"
+        case .focus:
+            return "Focus"
+        case .cafe:
+            return "Cafe"
+        case .lounge:
+            return "Lounge"
+        case .club:
+            return "Club"
+        }
+    }
 }

--- a/JipJung/JipJung/UI/Common/Extensions/String+Extension.swift
+++ b/JipJung/JipJung/UI/Common/Extensions/String+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  String+Extension.swift
+//  JipJung
+//
+//  Created by 오현식 on 2021/11/16.
+//
+
+import Foundation
+
+extension String {
+    var isNotEmpty: Bool {
+        return !self.isEmpty
+    }
+}

--- a/JipJung/JipJung/UI/Common/Extensions/UICollectionView+Extension.swift
+++ b/JipJung/JipJung/UI/Common/Extensions/UICollectionView+Extension.swift
@@ -10,15 +10,15 @@ import UIKit
 extension UICollectionView {
     enum CellIdentifier {
         case music
-        case genre
+        case soundTag
         case tag
         
         var value: String {
             switch self {
             case .music:
                 return String(describing: MusicCollectionViewCell.self)
-            case .genre:
-                return String(describing: GenreCollectionViewCell.self)
+            case .soundTag:
+                return String(describing: SoundTagCollectionViewCell.self)
             case .tag:
                 return String(describing: TagCollectionViewCell.self)
             }

--- a/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
+++ b/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
@@ -6,3 +6,37 @@
 //
 
 import Foundation
+import RxSwift
+import RxRelay
+
+protocol ExploreViewModelInput {
+    func search(tag: String)
+}
+
+protocol ExploreViewModelOutput {
+    var searchResult: BehaviorRelay<[Media]> { get }
+}
+
+final class ExploreViewModel: ExploreViewModelInput, ExploreViewModelOutput {
+    var searchResult: BehaviorRelay<[Media]> = BehaviorRelay<[Media]>(value: [])
+    let souundTagList: [SoundTag] = [SoundTag.all, SoundTag.nature, SoundTag.urban, SoundTag.relax, SoundTag.focus, SoundTag.focus, SoundTag.cafe, SoundTag.cafe, SoundTag.lounge, SoundTag.club]
+    
+    private var disposeBag: DisposeBag = DisposeBag()
+    
+    private let searchMediaUseCase: SearchMediaUseCase
+    
+    init(searchMediaUseCase: SearchMediaUseCase) {
+        self.searchMediaUseCase = searchMediaUseCase
+    }
+    
+    func search(tag: String) {
+        guard tag.isNotEmpty else { return }
+        searchMediaUseCase.searchResult
+            .bind { [weak self] in
+                self?.searchResult.accept($0)
+            }
+            .disposed(by: disposeBag)
+        
+        searchMediaUseCase.search(tag: tag)
+    }
+}

--- a/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
+++ b/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
@@ -15,11 +15,12 @@ protocol ExploreViewModelInput {
 
 protocol ExploreViewModelOutput {
     var searchResult: BehaviorRelay<[Media]> { get }
+    var soundTagList: [SoundTag] { get }
 }
 
 final class ExploreViewModel: ExploreViewModelInput, ExploreViewModelOutput {
     var searchResult: BehaviorRelay<[Media]> = BehaviorRelay<[Media]>(value: [])
-    let soundTagList: [SoundTag] = SoundTag.allCases
+    var soundTagList: [SoundTag] = SoundTag.allCases
     
     private var disposeBag: DisposeBag = DisposeBag()
     

--- a/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
+++ b/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxRelay
 
 protocol ExploreViewModelInput {
-    func search(tag: String)
+    func categorize(by tag: String)
 }
 
 protocol ExploreViewModelOutput {
@@ -30,7 +30,7 @@ final class ExploreViewModel: ExploreViewModelInput, ExploreViewModelOutput {
         self.searchMediaUseCase = searchMediaUseCase
     }
     
-    func search(tag: String) {
+    func categorize(by tag: String) {
         guard tag.isNotEmpty else { return }
         searchMediaUseCase.searchResult
             .bind { [weak self] in

--- a/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
+++ b/JipJung/JipJung/UI/Explore/Main/VIewModels/ExploreViewModel.swift
@@ -19,7 +19,7 @@ protocol ExploreViewModelOutput {
 
 final class ExploreViewModel: ExploreViewModelInput, ExploreViewModelOutput {
     var searchResult: BehaviorRelay<[Media]> = BehaviorRelay<[Media]>(value: [])
-    let souundTagList: [SoundTag] = [SoundTag.all, SoundTag.nature, SoundTag.urban, SoundTag.relax, SoundTag.focus, SoundTag.focus, SoundTag.cafe, SoundTag.cafe, SoundTag.lounge, SoundTag.club]
+    let soundTagList: [SoundTag] = SoundTag.allCases
     
     private var disposeBag: DisposeBag = DisposeBag()
     

--- a/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
@@ -168,9 +168,9 @@ extension ExploreViewController: UICollectionViewDelegate {
             let tag = viewModel?.souundTagList[safe: indexPath.item]?.value ?? ""
             viewModel?.search(tag: tag)
         } else if collectionView == soundCollectionView {
-            
+            navigationController?.pushViewController(MusicPlayerViewController(), animated: true)
         } else {
-           
+           return
         }
     }
 }

--- a/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import SnapKit
+import RxSwift
+import RxCocoa
 
 final class ExploreViewController: UIViewController {
     // MARK: - Subviews
@@ -25,7 +27,7 @@ final class ExploreViewController: UIViewController {
         return searchBar
     }()
     
-    private lazy var genreCollectionView: UICollectionView = {
+    private lazy var soundTagCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.sectionInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
@@ -36,8 +38,8 @@ final class ExploreViewController: UIViewController {
         categoryCollectionView.delegate = self
         categoryCollectionView.dataSource = self
         categoryCollectionView.register(
-            GenreCollectionViewCell.self,
-            forCellWithReuseIdentifier: UICollectionView.CellIdentifier.genre.value)
+            SoundTagCollectionViewCell.self,
+            forCellWithReuseIdentifier: UICollectionView.CellIdentifier.soundTag.value)
         return categoryCollectionView
     }()
 
@@ -59,9 +61,10 @@ final class ExploreViewController: UIViewController {
         return soundContentsCollectionView
     }()
     
-    // MARK: - Private Constants
+    // MARK: - Private Variables
     
-    private let category: [String] = [Genre.All, Genre.Melody, Genre.Relax, Genre.Urban, Genre.Nature, Genre.Techno, Genre.House, Genre.Disco, Genre.Hiphop, Genre.Jazz]
+    private var disposeBag: DisposeBag = DisposeBag()
+    private var viewModel: ExploreViewModel?
 
     // MARK: - Lifecycle Methods
     
@@ -69,11 +72,20 @@ final class ExploreViewController: UIViewController {
         super.viewDidLoad()
         
         configureUI()
+        bindUI()
+        viewModel?.search(tag: SoundTag.all.value)
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
+    // MARK: - Initializer
+
+    convenience init(viewModel: ExploreViewModel) {
+        self.init(nibName: nil, bundle: nil)
+        self.viewModel = viewModel
     }
     
     // MARK: - Helpers
@@ -97,18 +109,27 @@ final class ExploreViewController: UIViewController {
             $0.centerX.top.bottom.equalToSuperview()
         }
         
-        scrollContentView.addSubview(genreCollectionView)
-        genreCollectionView.snp.makeConstraints {
+        scrollContentView.addSubview(soundTagCollectionView)
+        soundTagCollectionView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
             $0.height.equalTo(30)
         }
         
         scrollContentView.addSubview(soundCollectionView)
         soundCollectionView.snp.makeConstraints {
-            $0.top.equalTo(genreCollectionView.snp.bottom).offset(20)
+            $0.top.equalTo(soundTagCollectionView.snp.bottom).offset(20)
             $0.height.equalTo(1200)
             $0.leading.trailing.bottom.equalToSuperview()
         }
+    }
+    
+    private func bindUI() {
+        viewModel?.searchResult
+            .bind(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.soundCollectionView.reloadData()
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -126,12 +147,14 @@ extension ExploreViewController: UISearchBarDelegate {
 
 extension ExploreViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        if collectionView == genreCollectionView {
-            return CGSize(width: category[indexPath.item].count * 10, height: 30)
+        if collectionView == soundTagCollectionView {
+            let count = viewModel?.souundTagList[safe: indexPath.item]?.value.count ?? 0
+            return CGSize(width: count * 10, height: 30)
         } else if collectionView == soundCollectionView {
             return CGSize(width: 180, height: 200)
+        } else {
+            return CGSize(width: 50, height: 50)
         }
-        return CGSize(width: 50, height: 50)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
@@ -139,27 +162,40 @@ extension ExploreViewController: UICollectionViewDelegateFlowLayout {
     }
 }
 
+extension ExploreViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if collectionView == soundTagCollectionView {
+            let tag = viewModel?.souundTagList[safe: indexPath.item]?.value ?? ""
+            viewModel?.search(tag: tag)
+        } else if collectionView == soundCollectionView {
+            
+        } else {
+           
+        }
+    }
+}
+
 extension ExploreViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        if collectionView == genreCollectionView {
-            return category.count
+        if collectionView == soundTagCollectionView {
+            return viewModel?.souundTagList.count ?? 0
         } else if collectionView == soundCollectionView {
-            return 10
+            return viewModel?.searchResult.value.count ?? 0
+        } else {
+            return 0
         }
-        return 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        if collectionView == genreCollectionView {
-            guard let cell = collectionView.cell(identifier: UICollectionView.CellIdentifier.genre.value, for: indexPath) as? GenreCollectionViewCell else { return  UICollectionViewCell() }
-            cell.genreLabel.text = category[indexPath.item]
+        if collectionView == soundTagCollectionView {
+            guard let cell = collectionView.cell(identifier: UICollectionView.CellIdentifier.soundTag.value, for: indexPath) as? SoundTagCollectionViewCell else { return  UICollectionViewCell() }
+            cell.soundTagLabel.text = viewModel?.souundTagList[safe: indexPath.item]?.value
             return cell
-        }
-        else if collectionView == soundCollectionView {
+        } else if collectionView == soundCollectionView {
             guard let cell = collectionView.cell(identifier: UICollectionView.CellIdentifier.music.value, for: indexPath) as? MusicCollectionViewCell else { return  UICollectionViewCell() }
+            cell.titleView.text = viewModel?.searchResult.value[indexPath.item].name
             return cell
-        }
-        else {
+        } else {
             return  UICollectionViewCell()
         }
     }

--- a/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
@@ -125,6 +125,7 @@ final class ExploreViewController: UIViewController {
     
     private func bindUI() {
         viewModel?.searchResult
+            .distinctUntilChanged()
             .bind(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 self.soundCollectionView.reloadData()

--- a/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
@@ -73,7 +73,7 @@ final class ExploreViewController: UIViewController {
         
         configureUI()
         bindUI()
-        viewModel?.search(tag: SoundTag.all.value)
+        viewModel?.categorize(by: SoundTag.all.value)
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -167,7 +167,7 @@ extension ExploreViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if collectionView == soundTagCollectionView {
             let tag = viewModel?.soundTagList[safe: indexPath.item]?.value ?? ""
-            viewModel?.search(tag: tag)
+            viewModel?.categorize(by: tag)
         } else if collectionView == soundCollectionView {
             navigationController?.pushViewController(MusicPlayerViewController(), animated: true)
         } else {

--- a/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
@@ -148,7 +148,7 @@ extension ExploreViewController: UISearchBarDelegate {
 extension ExploreViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         if collectionView == soundTagCollectionView {
-            let count = viewModel?.souundTagList[safe: indexPath.item]?.value.count ?? 0
+            let count = viewModel?.soundTagList[safe: indexPath.item]?.value.count ?? 0
             return CGSize(width: count * 10, height: 30)
         } else if collectionView == soundCollectionView {
             return CGSize(width: 180, height: 200)
@@ -165,7 +165,7 @@ extension ExploreViewController: UICollectionViewDelegateFlowLayout {
 extension ExploreViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if collectionView == soundTagCollectionView {
-            let tag = viewModel?.souundTagList[safe: indexPath.item]?.value ?? ""
+            let tag = viewModel?.soundTagList[safe: indexPath.item]?.value ?? ""
             viewModel?.search(tag: tag)
         } else if collectionView == soundCollectionView {
             navigationController?.pushViewController(MusicPlayerViewController(), animated: true)
@@ -178,7 +178,7 @@ extension ExploreViewController: UICollectionViewDelegate {
 extension ExploreViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if collectionView == soundTagCollectionView {
-            return viewModel?.souundTagList.count ?? 0
+            return viewModel?.soundTagList.count ?? 0
         } else if collectionView == soundCollectionView {
             return viewModel?.searchResult.value.count ?? 0
         } else {
@@ -189,7 +189,7 @@ extension ExploreViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if collectionView == soundTagCollectionView {
             guard let cell = collectionView.cell(identifier: UICollectionView.CellIdentifier.soundTag.value, for: indexPath) as? SoundTagCollectionViewCell else { return  UICollectionViewCell() }
-            cell.soundTagLabel.text = viewModel?.souundTagList[safe: indexPath.item]?.value
+            cell.soundTagLabel.text = viewModel?.soundTagList[safe: indexPath.item]?.value
             return cell
         } else if collectionView == soundCollectionView {
             guard let cell = collectionView.cell(identifier: UICollectionView.CellIdentifier.music.value, for: indexPath) as? MusicCollectionViewCell else { return  UICollectionViewCell() }

--- a/JipJung/JipJung/UI/Explore/Main/Views/SearchViewController.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/SearchViewController.swift
@@ -123,12 +123,14 @@ final class SearchViewController: UIViewController {
             .disposed(by: disposeBag)
         
         viewModel?.searchHistory
+            .distinctUntilChanged()
             .bind(onNext: { [weak self] _ in
                 self?.searchHistoryTableView.reloadData()
             })
             .disposed(by: disposeBag)
         
         viewModel?.searchResult
+            .distinctUntilChanged()
             .bind(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 self.soundCollectionView.reloadData()

--- a/JipJung/JipJung/UI/Explore/Main/Views/SoundTagCollectionViewCell.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/SoundTagCollectionViewCell.swift
@@ -8,15 +8,15 @@
 import UIKit
 import SnapKit
 
-class GenreCollectionViewCell: UICollectionViewCell {
+class SoundTagCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Subviews
     
-    lazy var genreLabel: UILabel = {
-        let genreLabel = UILabel()
-        genreLabel.textColor = .white
+    lazy var soundTagLabel: UILabel = {
+        let soundTagLabel = UILabel()
+        soundTagLabel.textColor = .white
         
-        return genreLabel
+        return soundTagLabel
     }()
     
     // MARK: - Initializers
@@ -32,8 +32,8 @@ class GenreCollectionViewCell: UICollectionViewCell {
     }
     
     private func configureUI() {
-        addSubview(genreLabel)
-        genreLabel.snp.makeConstraints {
+        addSubview(soundTagLabel)
+        soundTagLabel.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalToSuperview()
         }
     }

--- a/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
@@ -90,7 +90,7 @@ class MusicPlayerViewController: UIViewController {
     }
     
     @objc func backButtonTouched(_ sender: UIButton) {
-        self.dismiss(animated: true, completion: nil)
+        navigationController?.popViewController(animated: true)
     }
 }
 


### PR DESCRIPTION
# 작업 내용
- Explore 화면에서 선택된 태그에 해당되는 음원 목록을 보여준다.
  - SearchMediaUseCase 에 search(tag:) 메서드 구현.
  - ExploreViewModel 구현.
  - ExploreViewController에 ExploreViewModel 추가 및 바인딩.
  
- 음원 목록 중 특정 음원을 선택하면 음원 상세 화면으로 이동한다.
  - 음원 컬렉션 뷰 셀을 선택하면 음원 상헤 화면으로 네비게이션 방식으로 전환. 

# 관련된 이슈 번호
close #93 

# 스크린 샷(optional)
https://user-images.githubusercontent.com/81892038/141927540-21621b7b-5efb-45b9-880c-17d8c210eb6e.mov