### PR TITLE
🐛 Timer exit후 다시 실행되도록 수정, 타이머 시간 설정하기 기능 추가

### DIFF
--- a/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
@@ -220,7 +220,7 @@ final class InfinityFocusViewController: FocusViewController {
         startButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
-                self.viewModel?.changeTimerState(to: .running(isContinue: false))
+                self.viewModel?.changeTimerState(to: .running(isResume: false))
             }
             .disposed(by: disposeBag)
         
@@ -234,7 +234,7 @@ final class InfinityFocusViewController: FocusViewController {
         continueButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
-                self.viewModel?.changeTimerState(to: .running(isContinue: true))
+                self.viewModel?.changeTimerState(to: .running(isResume: true))
             }
             .disposed(by: disposeBag)
         

--- a/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
@@ -215,7 +215,7 @@ final class PomodoroFocusViewController: FocusViewController {
         startButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
-                self.viewModel?.changeTimerState(to: .running(isContinue: false))
+                self.viewModel?.changeTimerState(to: .running(isResume: false))
             }
             .disposed(by: disposeBag)
         
@@ -229,7 +229,7 @@ final class PomodoroFocusViewController: FocusViewController {
         continueButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
-                self.viewModel?.changeTimerState(to: .running(isContinue: true))
+                self.viewModel?.changeTimerState(to: .running(isResume: true))
             }
             .disposed(by: disposeBag)
         
@@ -293,9 +293,9 @@ final class PomodoroFocusViewController: FocusViewController {
         minuteLabel.isHidden = true
         viewModel?.startClockTimer()
         switch viewModel?.timerState.value {
-        case .running(isContinue: true):
+        case .running(isResume: true):
             resumeTimerProgressAnimation()
-        case .running(isContinue: false):
+        case .running(isResume: false):
             startTimeProgressAnimation()
         default:
             break

--- a/JipJung/JipJung/UI/Home/Home+Enums.swift
+++ b/JipJung/JipJung/UI/Home/Home+Enums.swift
@@ -75,6 +75,6 @@ enum FocusViewButtonSize {
 
 enum TimerState: Equatable {
     case ready
-    case running(isContinue: Bool)
+    case running(isResume: Bool)
     case paused
 }


### PR DESCRIPTION
# 작업 내용
- TimerExit후 다시 실행했을 때 ProgressBar가 나타나지 않는 버그 수정
- Timer지속시간이 고정 100초였던 기능을 시간 변경이 가능하도록 변경

# 관련된 이슈 번호
close #84 
