### PR TITLE
기본 에셋/더미 데이터 갱신, 홈 화면 clubView 추가

### DIFF
--- a/JipJung/JipJung.xcodeproj/project.pbxproj
+++ b/JipJung/JipJung.xcodeproj/project.pbxproj
@@ -45,6 +45,68 @@
 		B4015CD42739151B006BD14A /* RecentMusicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4015CD32739151B006BD14A /* RecentMusicViewController.swift */; };
 		B4015CD627391529006BD14A /* FavoriteMusicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4015CD527391529006BD14A /* FavoriteMusicViewController.swift */; };
 		B4015CD82739270C006BD14A /* SoundTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4015CD72739270C006BD14A /* SoundTagCollectionViewCell.swift */; };
+		B401E377274E2ED60065A9EA /* D002.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B401E371274E2ED60065A9EA /* D002.mp3 */; };
+		B401E378274E2ED60065A9EA /* D000.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B401E372274E2ED60065A9EA /* D000.mp3 */; };
+		B401E379274E2ED60065A9EA /* D001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E373274E2ED60065A9EA /* D001.jpg */; };
+		B401E37A274E2ED60065A9EA /* D000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E374274E2ED60065A9EA /* D000.jpg */; };
+		B401E37B274E2ED60065A9EA /* D001.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B401E375274E2ED60065A9EA /* D001.mp3 */; };
+		B401E37C274E2ED60065A9EA /* D002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E376274E2ED60065A9EA /* D002.jpg */; };
+		B401E392274E2EE70065A9EA /* M016.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E37D274E2EE60065A9EA /* M016.jpg */; };
+		B401E393274E2EE70065A9EA /* M010.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E37E274E2EE60065A9EA /* M010.jpg */; };
+		B401E394274E2EE70065A9EA /* M018.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E37F274E2EE60065A9EA /* M018.jpg */; };
+		B401E395274E2EE70065A9EA /* M013.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E380274E2EE60065A9EA /* M013.jpg */; };
+		B401E396274E2EE70065A9EA /* M003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E381274E2EE60065A9EA /* M003.jpg */; };
+		B401E397274E2EE70065A9EA /* M007.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E382274E2EE60065A9EA /* M007.jpg */; };
+		B401E398274E2EE70065A9EA /* M004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E383274E2EE60065A9EA /* M004.jpg */; };
+		B401E399274E2EE70065A9EA /* M009.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E384274E2EE60065A9EA /* M009.jpg */; };
+		B401E39A274E2EE70065A9EA /* M002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E385274E2EE60065A9EA /* M002.jpg */; };
+		B401E39B274E2EE70065A9EA /* M001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E386274E2EE60065A9EA /* M001.jpg */; };
+		B401E39C274E2EE70065A9EA /* M000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E387274E2EE60065A9EA /* M000.jpg */; };
+		B401E39D274E2EE70065A9EA /* M008.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E388274E2EE60065A9EA /* M008.jpg */; };
+		B401E39E274E2EE70065A9EA /* M011.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E389274E2EE60065A9EA /* M011.jpg */; };
+		B401E39F274E2EE70065A9EA /* M012.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E38A274E2EE70065A9EA /* M012.jpg */; };
+		B401E3A0274E2EE70065A9EA /* M017.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E38B274E2EE70065A9EA /* M017.jpg */; };
+		B401E3A1274E2EE70065A9EA /* M015.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E38C274E2EE70065A9EA /* M015.jpg */; };
+		B401E3A2274E2EE70065A9EA /* M019.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E38D274E2EE70065A9EA /* M019.jpg */; };
+		B401E3A3274E2EE70065A9EA /* M020.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E38E274E2EE70065A9EA /* M020.jpg */; };
+		B401E3A4274E2EE70065A9EA /* M014.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E38F274E2EE70065A9EA /* M014.jpg */; };
+		B401E3A5274E2EE70065A9EA /* M005.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E390274E2EE70065A9EA /* M005.jpg */; };
+		B401E3A6274E2EE70065A9EA /* M006.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E391274E2EE70065A9EA /* M006.jpg */; };
+		B401E3B0274E2F0B0065A9EA /* N001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3A7274E2F0B0065A9EA /* N001.jpg */; };
+		B401E3B1274E2F0B0065A9EA /* N001.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B401E3A8274E2F0B0065A9EA /* N001.WAV */; };
+		B401E3B2274E2F0B0065A9EA /* N000.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B401E3A9274E2F0B0065A9EA /* N000.WAV */; };
+		B401E3B3274E2F0B0065A9EA /* N001.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3AA274E2F0B0065A9EA /* N001.mp4 */; };
+		B401E3B4274E2F0B0065A9EA /* N000.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3AB274E2F0B0065A9EA /* N000.mp4 */; };
+		B401E3B5274E2F0B0065A9EA /* N000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3AC274E2F0B0065A9EA /* N000.jpg */; };
+		B401E3B6274E2F0B0065A9EA /* N002.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B401E3AD274E2F0B0065A9EA /* N002.WAV */; };
+		B401E3B7274E2F0B0065A9EA /* N002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3AE274E2F0B0065A9EA /* N002.jpg */; };
+		B401E3B8274E2F0B0065A9EA /* N002.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3AF274E2F0B0065A9EA /* N002.mp4 */; };
+		B401E3BC274E2F540065A9EA /* U001.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B401E3B9274E2F540065A9EA /* U001.WAV */; };
+		B401E3BD274E2F540065A9EA /* U001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3BA274E2F540065A9EA /* U001.jpg */; };
+		B401E3BE274E2F540065A9EA /* U001.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3BB274E2F540065A9EA /* U001.mp4 */; };
+		B401E3CB274E2F920065A9EA /* D003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3C9274E2F910065A9EA /* D003.jpg */; };
+		B401E3CC274E2F920065A9EA /* D004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3CA274E2F920065A9EA /* D004.jpg */; };
+		B401E3D7274E2FE30065A9EA /* N003.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3CD274E2FE20065A9EA /* N003.mp4 */; };
+		B401E3D8274E2FE30065A9EA /* N007.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3CE274E2FE20065A9EA /* N007.mp4 */; };
+		B401E3D9274E2FE30065A9EA /* N004.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3CF274E2FE20065A9EA /* N004.mp4 */; };
+		B401E3DA274E2FE30065A9EA /* N006.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3D0274E2FE20065A9EA /* N006.jpg */; };
+		B401E3DB274E2FE30065A9EA /* N005.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3D1274E2FE20065A9EA /* N005.jpg */; };
+		B401E3DC274E2FE30065A9EA /* N005.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3D2274E2FE20065A9EA /* N005.mp4 */; };
+		B401E3DD274E2FE30065A9EA /* N004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3D3274E2FE30065A9EA /* N004.jpg */; };
+		B401E3DE274E2FE30065A9EA /* N006.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3D4274E2FE30065A9EA /* N006.mp4 */; };
+		B401E3DF274E2FE30065A9EA /* N003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3D5274E2FE30065A9EA /* N003.jpg */; };
+		B401E3E0274E2FE30065A9EA /* N007.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3D6274E2FE30065A9EA /* N007.jpg */; };
+		B401E3EA274E30640065A9EA /* U005.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3E9274E30640065A9EA /* U005.jpg */; };
+		B401E3EE274E30D20065A9EA /* U002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3EC274E30D20065A9EA /* U002.jpg */; };
+		B401E3EF274E30D20065A9EA /* U002.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3ED274E30D20065A9EA /* U002.mp4 */; };
+		B401E3F2274E31A40065A9EA /* U000.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3F0274E31A40065A9EA /* U000.mp4 */; };
+		B401E3F3274E31A40065A9EA /* U000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3F1274E31A40065A9EA /* U000.jpg */; };
+		B401E3F5274E31BD0065A9EA /* U004.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B401E3F4274E31BD0065A9EA /* U004.WAV */; };
+		B401E3FA274E4E160065A9EA /* U004.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3F6274E4E160065A9EA /* U004.mp4 */; };
+		B401E3FB274E4E160065A9EA /* U003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3F7274E4E160065A9EA /* U003.jpg */; };
+		B401E3FC274E4E160065A9EA /* U004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B401E3F8274E4E160065A9EA /* U004.jpg */; };
+		B401E3FD274E4E160065A9EA /* U003.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B401E3F9274E4E160065A9EA /* U003.mp4 */; };
+		B401E3FF274E4E700065A9EA /* U003.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B401E3FE274E4E700065A9EA /* U003.WAV */; };
 		B40D1FA9273B5F1900881A49 /* DefaultFocusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D1FA8273B5F1900881A49 /* DefaultFocusViewController.swift */; };
 		B40D1FAB273B5F2100881A49 /* DefaultFocusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D1FAA273B5F2100881A49 /* DefaultFocusViewModel.swift */; };
 		B40D1FAD273B5F2800881A49 /* PomodoroFocusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D1FAC273B5F2700881A49 /* PomodoroFocusViewController.swift */; };
@@ -65,57 +127,6 @@
 		B490FE38274CBEB3008A4454 /* ClubSKScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = B490FE37274CBEB3008A4454 /* ClubSKScene.swift */; };
 		B4B780DF2741F6FA0080DC28 /* BreathFocusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B780DE2741F6FA0080DC28 /* BreathFocusViewController.swift */; };
 		B4B780E12741F7070080DC28 /* BreathFocusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B780E02741F7070080DC28 /* BreathFocusViewModel.swift */; };
-		B4E420D927460BBB00C39545 /* M014.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420A627460BB900C39545 /* M014.jpg */; };
-		B4E420DA27460BBB00C39545 /* N003.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420A727460BB900C39545 /* N003.mp4 */; };
-		B4E420DB27460BBB00C39545 /* M010.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420A827460BB900C39545 /* M010.jpg */; };
-		B4E420DC27460BBB00C39545 /* M008.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420A927460BB900C39545 /* M008.jpg */; };
-		B4E420DD27460BBB00C39545 /* N003.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420AA27460BB900C39545 /* N003.WAV */; };
-		B4E420DE27460BBB00C39545 /* U000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420AB27460BB900C39545 /* U000.jpg */; };
-		B4E420DF27460BBB00C39545 /* N000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420AC27460BB900C39545 /* N000.jpg */; };
-		B4E420E027460BBB00C39545 /* M020.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420AD27460BB900C39545 /* M020.jpg */; };
-		B4E420E127460BBB00C39545 /* M000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420AE27460BB900C39545 /* M000.jpg */; };
-		B4E420E227460BBB00C39545 /* N004.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420AF27460BB900C39545 /* N004.WAV */; };
-		B4E420E327460BBB00C39545 /* U001.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B027460BB900C39545 /* U001.mp4 */; };
-		B4E420E427460BBB00C39545 /* U004.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B127460BB900C39545 /* U004.WAV */; };
-		B4E420E527460BBB00C39545 /* U002.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B227460BB900C39545 /* U002.mp4 */; };
-		B4E420E627460BBB00C39545 /* N002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B327460BB900C39545 /* N002.jpg */; };
-		B4E420E727460BBB00C39545 /* M016.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B427460BB900C39545 /* M016.jpg */; };
-		B4E420E827460BBB00C39545 /* M005.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B527460BB900C39545 /* M005.jpg */; };
-		B4E420E927460BBB00C39545 /* U001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B627460BB900C39545 /* U001.jpg */; };
-		B4E420EA27460BBB00C39545 /* N003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B727460BB900C39545 /* N003.jpg */; };
-		B4E420EB27460BBB00C39545 /* U001.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B827460BBA00C39545 /* U001.WAV */; };
-		B4E420EC27460BBB00C39545 /* M001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420B927460BBA00C39545 /* M001.jpg */; };
-		B4E420ED27460BBB00C39545 /* N001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420BA27460BBA00C39545 /* N001.jpg */; };
-		B4E420EE27460BBB00C39545 /* M007.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420BB27460BBA00C39545 /* M007.jpg */; };
-		B4E420EF27460BBB00C39545 /* U003.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420BC27460BBA00C39545 /* U003.mp4 */; };
-		B4E420F027460BBB00C39545 /* N000.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420BD27460BBA00C39545 /* N000.mp4 */; };
-		B4E420F127460BBB00C39545 /* U002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420BE27460BBA00C39545 /* U002.jpg */; };
-		B4E420F227460BBB00C39545 /* M012.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420BF27460BBA00C39545 /* M012.jpg */; };
-		B4E420F327460BBB00C39545 /* M018.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C027460BBA00C39545 /* M018.jpg */; };
-		B4E420F427460BBB00C39545 /* U004.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C127460BBA00C39545 /* U004.mp4 */; };
-		B4E420F527460BBB00C39545 /* U000.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C227460BBA00C39545 /* U000.mp4 */; };
-		B4E420F627460BBB00C39545 /* M002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C327460BBA00C39545 /* M002.jpg */; };
-		B4E420F727460BBB00C39545 /* N002.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C427460BBA00C39545 /* N002.mp4 */; };
-		B4E420F827460BBB00C39545 /* M006.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C527460BBA00C39545 /* M006.jpg */; };
-		B4E420F927460BBB00C39545 /* U000.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C627460BBA00C39545 /* U000.WAV */; };
-		B4E420FA27460BBB00C39545 /* N004.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C727460BBA00C39545 /* N004.mp4 */; };
-		B4E420FB27460BBB00C39545 /* N000.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C827460BBA00C39545 /* N000.WAV */; };
-		B4E420FC27460BBB00C39545 /* M013.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420C927460BBA00C39545 /* M013.jpg */; };
-		B4E420FD27460BBB00C39545 /* M011.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420CA27460BBA00C39545 /* M011.jpg */; };
-		B4E420FE27460BBB00C39545 /* M004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420CB27460BBA00C39545 /* M004.jpg */; };
-		B4E420FF27460BBB00C39545 /* M003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420CC27460BBA00C39545 /* M003.jpg */; };
-		B4E4210027460BBB00C39545 /* U004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420CD27460BBA00C39545 /* U004.jpg */; };
-		B4E4210127460BBB00C39545 /* U002.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420CE27460BBA00C39545 /* U002.WAV */; };
-		B4E4210227460BBB00C39545 /* U003.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420CF27460BBA00C39545 /* U003.WAV */; };
-		B4E4210327460BBB00C39545 /* U003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D027460BBA00C39545 /* U003.jpg */; };
-		B4E4210427460BBB00C39545 /* M009.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D127460BBA00C39545 /* M009.jpg */; };
-		B4E4210527460BBB00C39545 /* M015.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D227460BBA00C39545 /* M015.jpg */; };
-		B4E4210627460BBB00C39545 /* N001.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D327460BBB00C39545 /* N001.mp4 */; };
-		B4E4210727460BBB00C39545 /* N004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D427460BBB00C39545 /* N004.jpg */; };
-		B4E4210827460BBB00C39545 /* N001.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D527460BBB00C39545 /* N001.WAV */; };
-		B4E4210927460BBB00C39545 /* M017.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D627460BBB00C39545 /* M017.jpg */; };
-		B4E4210A27460BBB00C39545 /* N002.WAV in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D727460BBB00C39545 /* N002.WAV */; };
-		B4E4210B27460BBB00C39545 /* M019.jpg in Resources */ = {isa = PBXBuildFile; fileRef = B4E420D827460BBB00C39545 /* M019.jpg */; };
 		B4E4210D27463C3D00C39545 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E4210C27463C3D00C39545 /* UIColor+Extension.swift */; };
 		B4E4210F274673E400C39545 /* UICollectionViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E4210E274673E300C39545 /* UICollectionViewCell+Extension.swift */; };
 		B4E421112746753B00C39545 /* UITableViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E421102746753B00C39545 /* UITableViewCell+Extension.swift */; };
@@ -138,57 +149,6 @@
 		DD4D030527425611007AA4DD /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4D030427425610007AA4DD /* UILabel+Extension.swift */; };
 		DD4D03072743BBB9007AA4DD /* MaximCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4D03062743BBB9007AA4DD /* MaximCollectionViewCell.swift */; };
 		DD4D030927449AAC007AA4DD /* MaximPresenterObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4D030827449AAC007AA4DD /* MaximPresenterObject.swift */; };
-		DD6E0B2C27466CC60086D374 /* N000.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AED27466CC50086D374 /* N000.mp4 */; };
-		DD6E0B2D27466CC60086D374 /* M002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AEE27466CC50086D374 /* M002.jpg */; };
-		DD6E0B2E27466CC60086D374 /* M007.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AEF27466CC50086D374 /* M007.jpg */; };
-		DD6E0B3027466CC60086D374 /* U000.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF127466CC50086D374 /* U000.WAV */; };
-		DD6E0B3127466CC60086D374 /* N002.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF227466CC50086D374 /* N002.mp4 */; };
-		DD6E0B3227466CC60086D374 /* N001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF327466CC50086D374 /* N001.jpg */; };
-		DD6E0B3327466CC60086D374 /* U001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF427466CC50086D374 /* U001.jpg */; };
-		DD6E0B3427466CC60086D374 /* U002.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF527466CC50086D374 /* U002.WAV */; };
-		DD6E0B3527466CC60086D374 /* M020.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF627466CC50086D374 /* M020.jpg */; };
-		DD6E0B3627466CC60086D374 /* M016.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF727466CC50086D374 /* M016.jpg */; };
-		DD6E0B3827466CC60086D374 /* N002.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AF927466CC50086D374 /* N002.WAV */; };
-		DD6E0B3927466CC60086D374 /* N004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AFA27466CC50086D374 /* N004.jpg */; };
-		DD6E0B3A27466CC60086D374 /* M001.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AFB27466CC50086D374 /* M001.jpg */; };
-		DD6E0B3C27466CC60086D374 /* N003.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AFD27466CC50086D374 /* N003.mp4 */; };
-		DD6E0B3D27466CC60086D374 /* U004.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AFE27466CC50086D374 /* U004.WAV */; };
-		DD6E0B3E27466CC60086D374 /* U003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0AFF27466CC50086D374 /* U003.jpg */; };
-		DD6E0B3F27466CC60086D374 /* N002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0027466CC50086D374 /* N002.jpg */; };
-		DD6E0B4027466CC60086D374 /* M010.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0127466CC50086D374 /* M010.jpg */; };
-		DD6E0B4127466CC60086D374 /* U001.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0227466CC50086D374 /* U001.WAV */; };
-		DD6E0B4227466CC60086D374 /* N003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0327466CC50086D374 /* N003.jpg */; };
-		DD6E0B4327466CC60086D374 /* U001.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0427466CC50086D374 /* U001.mp4 */; };
-		DD6E0B4527466CC60086D374 /* M006.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0627466CC50086D374 /* M006.jpg */; };
-		DD6E0B4627466CC60086D374 /* U003.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0727466CC50086D374 /* U003.WAV */; };
-		DD6E0B4827466CC60086D374 /* M013.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0927466CC50086D374 /* M013.jpg */; };
-		DD6E0B4927466CC60086D374 /* N004.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0A27466CC50086D374 /* N004.WAV */; };
-		DD6E0B4A27466CC60086D374 /* M005.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0B27466CC50086D374 /* M005.jpg */; };
-		DD6E0B4B27466CC60086D374 /* U004.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0C27466CC50086D374 /* U004.mp4 */; };
-		DD6E0B4C27466CC60086D374 /* M004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0D27466CC50086D374 /* M004.jpg */; };
-		DD6E0B4D27466CC60086D374 /* N000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0E27466CC50086D374 /* N000.jpg */; };
-		DD6E0B4E27466CC60086D374 /* M019.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B0F27466CC50086D374 /* M019.jpg */; };
-		DD6E0B4F27466CC60086D374 /* N001.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1027466CC50086D374 /* N001.WAV */; };
-		DD6E0B5027466CC60086D374 /* M017.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1127466CC50086D374 /* M017.jpg */; };
-		DD6E0B5227466CC60086D374 /* N004.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1327466CC50086D374 /* N004.mp4 */; };
-		DD6E0B5327466CC60086D374 /* N000.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1427466CC50086D374 /* N000.WAV */; };
-		DD6E0B5427466CC60086D374 /* U000.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1527466CC50086D374 /* U000.mp4 */; };
-		DD6E0B5527466CC60086D374 /* M009.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1627466CC50086D374 /* M009.jpg */; };
-		DD6E0B5627466CC60086D374 /* U004.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1727466CC50086D374 /* U004.jpg */; };
-		DD6E0B5727466CC60086D374 /* M000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1827466CC50086D374 /* M000.jpg */; };
-		DD6E0B5827466CC60086D374 /* N001.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1927466CC50086D374 /* N001.mp4 */; };
-		DD6E0B5A27466CC60086D374 /* M008.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1B27466CC50086D374 /* M008.jpg */; };
-		DD6E0B5B27466CC60086D374 /* U002.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1C27466CC50086D374 /* U002.mp4 */; };
-		DD6E0B5E27466CC60086D374 /* M014.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B1F27466CC50086D374 /* M014.jpg */; };
-		DD6E0B6027466CC60086D374 /* U003.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2127466CC60086D374 /* U003.mp4 */; };
-		DD6E0B6127466CC60086D374 /* M011.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2227466CC60086D374 /* M011.jpg */; };
-		DD6E0B6227466CC60086D374 /* M018.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2327466CC60086D374 /* M018.jpg */; };
-		DD6E0B6327466CC60086D374 /* U000.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2427466CC60086D374 /* U000.jpg */; };
-		DD6E0B6427466CC60086D374 /* M003.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2527466CC60086D374 /* M003.jpg */; };
-		DD6E0B6627466CC60086D374 /* M015.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2727466CC60086D374 /* M015.jpg */; };
-		DD6E0B6727466CC60086D374 /* U002.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2827466CC60086D374 /* U002.jpg */; };
-		DD6E0B6827466CC60086D374 /* N003.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2927466CC60086D374 /* N003.WAV */; };
-		DD6E0B6927466CC60086D374 /* M012.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD6E0B2A27466CC60086D374 /* M012.jpg */; };
 		DD6FD1F4274BBA2700568A4E /* MeDailyStaticsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6FD1F3274BBA2700568A4E /* MeDailyStaticsCollectionViewCell.swift */; };
 		DD6FD1F6274BCEB300568A4E /* Me+Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6FD1F5274BCEB300568A4E /* Me+Enums.swift */; };
 		DD6FD1F8274BD08400568A4E /* MeHeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6FD1F7274BD08400568A4E /* MeHeaderCollectionReusableView.swift */; };
@@ -296,6 +256,69 @@
 		B4015CD32739151B006BD14A /* RecentMusicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentMusicViewController.swift; sourceTree = "<group>"; };
 		B4015CD527391529006BD14A /* FavoriteMusicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteMusicViewController.swift; sourceTree = "<group>"; };
 		B4015CD72739270C006BD14A /* SoundTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundTagCollectionViewCell.swift; sourceTree = "<group>"; };
+		B401E371274E2ED60065A9EA /* D002.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = D002.mp3; sourceTree = "<group>"; };
+		B401E372274E2ED60065A9EA /* D000.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = D000.mp3; sourceTree = "<group>"; };
+		B401E373274E2ED60065A9EA /* D001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = D001.jpg; sourceTree = "<group>"; };
+		B401E374274E2ED60065A9EA /* D000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = D000.jpg; sourceTree = "<group>"; };
+		B401E375274E2ED60065A9EA /* D001.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = D001.mp3; sourceTree = "<group>"; };
+		B401E376274E2ED60065A9EA /* D002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = D002.jpg; sourceTree = "<group>"; };
+		B401E37D274E2EE60065A9EA /* M016.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M016.jpg; sourceTree = "<group>"; };
+		B401E37E274E2EE60065A9EA /* M010.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M010.jpg; sourceTree = "<group>"; };
+		B401E37F274E2EE60065A9EA /* M018.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M018.jpg; sourceTree = "<group>"; };
+		B401E380274E2EE60065A9EA /* M013.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M013.jpg; sourceTree = "<group>"; };
+		B401E381274E2EE60065A9EA /* M003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M003.jpg; sourceTree = "<group>"; };
+		B401E382274E2EE60065A9EA /* M007.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M007.jpg; sourceTree = "<group>"; };
+		B401E383274E2EE60065A9EA /* M004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M004.jpg; sourceTree = "<group>"; };
+		B401E384274E2EE60065A9EA /* M009.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M009.jpg; sourceTree = "<group>"; };
+		B401E385274E2EE60065A9EA /* M002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M002.jpg; sourceTree = "<group>"; };
+		B401E386274E2EE60065A9EA /* M001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M001.jpg; sourceTree = "<group>"; };
+		B401E387274E2EE60065A9EA /* M000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M000.jpg; sourceTree = "<group>"; };
+		B401E388274E2EE60065A9EA /* M008.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M008.jpg; sourceTree = "<group>"; };
+		B401E389274E2EE60065A9EA /* M011.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M011.jpg; sourceTree = "<group>"; };
+		B401E38A274E2EE70065A9EA /* M012.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M012.jpg; sourceTree = "<group>"; };
+		B401E38B274E2EE70065A9EA /* M017.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M017.jpg; sourceTree = "<group>"; };
+		B401E38C274E2EE70065A9EA /* M015.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M015.jpg; sourceTree = "<group>"; };
+		B401E38D274E2EE70065A9EA /* M019.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M019.jpg; sourceTree = "<group>"; };
+		B401E38E274E2EE70065A9EA /* M020.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M020.jpg; sourceTree = "<group>"; };
+		B401E38F274E2EE70065A9EA /* M014.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M014.jpg; sourceTree = "<group>"; };
+		B401E390274E2EE70065A9EA /* M005.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M005.jpg; sourceTree = "<group>"; };
+		B401E391274E2EE70065A9EA /* M006.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M006.jpg; sourceTree = "<group>"; };
+		B401E3A7274E2F0B0065A9EA /* N001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N001.jpg; sourceTree = "<group>"; };
+		B401E3A8274E2F0B0065A9EA /* N001.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N001.WAV; sourceTree = "<group>"; };
+		B401E3A9274E2F0B0065A9EA /* N000.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N000.WAV; sourceTree = "<group>"; };
+		B401E3AA274E2F0B0065A9EA /* N001.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N001.mp4; sourceTree = "<group>"; };
+		B401E3AB274E2F0B0065A9EA /* N000.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N000.mp4; sourceTree = "<group>"; };
+		B401E3AC274E2F0B0065A9EA /* N000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N000.jpg; sourceTree = "<group>"; };
+		B401E3AD274E2F0B0065A9EA /* N002.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N002.WAV; sourceTree = "<group>"; };
+		B401E3AE274E2F0B0065A9EA /* N002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N002.jpg; sourceTree = "<group>"; };
+		B401E3AF274E2F0B0065A9EA /* N002.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N002.mp4; sourceTree = "<group>"; };
+		B401E3B9274E2F540065A9EA /* U001.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U001.WAV; sourceTree = "<group>"; };
+		B401E3BA274E2F540065A9EA /* U001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U001.jpg; sourceTree = "<group>"; };
+		B401E3BB274E2F540065A9EA /* U001.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U001.mp4; sourceTree = "<group>"; };
+		B401E3C9274E2F910065A9EA /* D003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = D003.jpg; sourceTree = "<group>"; };
+		B401E3CA274E2F920065A9EA /* D004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = D004.jpg; sourceTree = "<group>"; };
+		B401E3CD274E2FE20065A9EA /* N003.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N003.mp4; sourceTree = "<group>"; };
+		B401E3CE274E2FE20065A9EA /* N007.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N007.mp4; sourceTree = "<group>"; };
+		B401E3CF274E2FE20065A9EA /* N004.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N004.mp4; sourceTree = "<group>"; };
+		B401E3D0274E2FE20065A9EA /* N006.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N006.jpg; sourceTree = "<group>"; };
+		B401E3D1274E2FE20065A9EA /* N005.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N005.jpg; sourceTree = "<group>"; };
+		B401E3D2274E2FE20065A9EA /* N005.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N005.mp4; sourceTree = "<group>"; };
+		B401E3D3274E2FE30065A9EA /* N004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N004.jpg; sourceTree = "<group>"; };
+		B401E3D4274E2FE30065A9EA /* N006.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N006.mp4; sourceTree = "<group>"; };
+		B401E3D5274E2FE30065A9EA /* N003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N003.jpg; sourceTree = "<group>"; };
+		B401E3D6274E2FE30065A9EA /* N007.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N007.jpg; sourceTree = "<group>"; };
+		B401E3E9274E30640065A9EA /* U005.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U005.jpg; sourceTree = "<group>"; };
+		B401E3EB274E30850065A9EA /* U005.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U005.mp4; sourceTree = "<group>"; };
+		B401E3EC274E30D20065A9EA /* U002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U002.jpg; sourceTree = "<group>"; };
+		B401E3ED274E30D20065A9EA /* U002.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U002.mp4; sourceTree = "<group>"; };
+		B401E3F0274E31A40065A9EA /* U000.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U000.mp4; sourceTree = "<group>"; };
+		B401E3F1274E31A40065A9EA /* U000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U000.jpg; sourceTree = "<group>"; };
+		B401E3F4274E31BD0065A9EA /* U004.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U004.WAV; sourceTree = "<group>"; };
+		B401E3F6274E4E160065A9EA /* U004.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U004.mp4; sourceTree = "<group>"; };
+		B401E3F7274E4E160065A9EA /* U003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U003.jpg; sourceTree = "<group>"; };
+		B401E3F8274E4E160065A9EA /* U004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U004.jpg; sourceTree = "<group>"; };
+		B401E3F9274E4E160065A9EA /* U003.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U003.mp4; sourceTree = "<group>"; };
+		B401E3FE274E4E700065A9EA /* U003.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U003.WAV; sourceTree = "<group>"; };
 		B40D1FA8273B5F1900881A49 /* DefaultFocusViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultFocusViewController.swift; sourceTree = "<group>"; };
 		B40D1FAA273B5F2100881A49 /* DefaultFocusViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultFocusViewModel.swift; sourceTree = "<group>"; };
 		B40D1FAC273B5F2700881A49 /* PomodoroFocusViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PomodoroFocusViewController.swift; sourceTree = "<group>"; };
@@ -316,57 +339,6 @@
 		B490FE37274CBEB3008A4454 /* ClubSKScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubSKScene.swift; sourceTree = "<group>"; };
 		B4B780DE2741F6FA0080DC28 /* BreathFocusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathFocusViewController.swift; sourceTree = "<group>"; };
 		B4B780E02741F7070080DC28 /* BreathFocusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathFocusViewModel.swift; sourceTree = "<group>"; };
-		B4E420A627460BB900C39545 /* M014.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M014.jpg; sourceTree = "<group>"; };
-		B4E420A727460BB900C39545 /* N003.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N003.mp4; sourceTree = "<group>"; };
-		B4E420A827460BB900C39545 /* M010.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M010.jpg; sourceTree = "<group>"; };
-		B4E420A927460BB900C39545 /* M008.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M008.jpg; sourceTree = "<group>"; };
-		B4E420AA27460BB900C39545 /* N003.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N003.WAV; sourceTree = "<group>"; };
-		B4E420AB27460BB900C39545 /* U000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U000.jpg; sourceTree = "<group>"; };
-		B4E420AC27460BB900C39545 /* N000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N000.jpg; sourceTree = "<group>"; };
-		B4E420AD27460BB900C39545 /* M020.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M020.jpg; sourceTree = "<group>"; };
-		B4E420AE27460BB900C39545 /* M000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M000.jpg; sourceTree = "<group>"; };
-		B4E420AF27460BB900C39545 /* N004.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N004.WAV; sourceTree = "<group>"; };
-		B4E420B027460BB900C39545 /* U001.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U001.mp4; sourceTree = "<group>"; };
-		B4E420B127460BB900C39545 /* U004.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U004.WAV; sourceTree = "<group>"; };
-		B4E420B227460BB900C39545 /* U002.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U002.mp4; sourceTree = "<group>"; };
-		B4E420B327460BB900C39545 /* N002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N002.jpg; sourceTree = "<group>"; };
-		B4E420B427460BB900C39545 /* M016.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M016.jpg; sourceTree = "<group>"; };
-		B4E420B527460BB900C39545 /* M005.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M005.jpg; sourceTree = "<group>"; };
-		B4E420B627460BB900C39545 /* U001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U001.jpg; sourceTree = "<group>"; };
-		B4E420B727460BB900C39545 /* N003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N003.jpg; sourceTree = "<group>"; };
-		B4E420B827460BBA00C39545 /* U001.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U001.WAV; sourceTree = "<group>"; };
-		B4E420B927460BBA00C39545 /* M001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M001.jpg; sourceTree = "<group>"; };
-		B4E420BA27460BBA00C39545 /* N001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N001.jpg; sourceTree = "<group>"; };
-		B4E420BB27460BBA00C39545 /* M007.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M007.jpg; sourceTree = "<group>"; };
-		B4E420BC27460BBA00C39545 /* U003.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U003.mp4; sourceTree = "<group>"; };
-		B4E420BD27460BBA00C39545 /* N000.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N000.mp4; sourceTree = "<group>"; };
-		B4E420BE27460BBA00C39545 /* U002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U002.jpg; sourceTree = "<group>"; };
-		B4E420BF27460BBA00C39545 /* M012.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M012.jpg; sourceTree = "<group>"; };
-		B4E420C027460BBA00C39545 /* M018.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M018.jpg; sourceTree = "<group>"; };
-		B4E420C127460BBA00C39545 /* U004.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U004.mp4; sourceTree = "<group>"; };
-		B4E420C227460BBA00C39545 /* U000.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U000.mp4; sourceTree = "<group>"; };
-		B4E420C327460BBA00C39545 /* M002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M002.jpg; sourceTree = "<group>"; };
-		B4E420C427460BBA00C39545 /* N002.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N002.mp4; sourceTree = "<group>"; };
-		B4E420C527460BBA00C39545 /* M006.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M006.jpg; sourceTree = "<group>"; };
-		B4E420C627460BBA00C39545 /* U000.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U000.WAV; sourceTree = "<group>"; };
-		B4E420C727460BBA00C39545 /* N004.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N004.mp4; sourceTree = "<group>"; };
-		B4E420C827460BBA00C39545 /* N000.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N000.WAV; sourceTree = "<group>"; };
-		B4E420C927460BBA00C39545 /* M013.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M013.jpg; sourceTree = "<group>"; };
-		B4E420CA27460BBA00C39545 /* M011.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M011.jpg; sourceTree = "<group>"; };
-		B4E420CB27460BBA00C39545 /* M004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M004.jpg; sourceTree = "<group>"; };
-		B4E420CC27460BBA00C39545 /* M003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M003.jpg; sourceTree = "<group>"; };
-		B4E420CD27460BBA00C39545 /* U004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U004.jpg; sourceTree = "<group>"; };
-		B4E420CE27460BBA00C39545 /* U002.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U002.WAV; sourceTree = "<group>"; };
-		B4E420CF27460BBA00C39545 /* U003.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U003.WAV; sourceTree = "<group>"; };
-		B4E420D027460BBA00C39545 /* U003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U003.jpg; sourceTree = "<group>"; };
-		B4E420D127460BBA00C39545 /* M009.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M009.jpg; sourceTree = "<group>"; };
-		B4E420D227460BBA00C39545 /* M015.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M015.jpg; sourceTree = "<group>"; };
-		B4E420D327460BBB00C39545 /* N001.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N001.mp4; sourceTree = "<group>"; };
-		B4E420D427460BBB00C39545 /* N004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N004.jpg; sourceTree = "<group>"; };
-		B4E420D527460BBB00C39545 /* N001.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N001.WAV; sourceTree = "<group>"; };
-		B4E420D627460BBB00C39545 /* M017.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M017.jpg; sourceTree = "<group>"; };
-		B4E420D727460BBB00C39545 /* N002.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N002.WAV; sourceTree = "<group>"; };
-		B4E420D827460BBB00C39545 /* M019.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M019.jpg; sourceTree = "<group>"; };
 		B4E4210C27463C3D00C39545 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		B4E4210E274673E300C39545 /* UICollectionViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Extension.swift"; sourceTree = "<group>"; };
 		B4E421102746753B00C39545 /* UITableViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Extension.swift"; sourceTree = "<group>"; };
@@ -393,69 +365,6 @@
 		DD4D030427425610007AA4DD /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		DD4D03062743BBB9007AA4DD /* MaximCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaximCollectionViewCell.swift; sourceTree = "<group>"; };
 		DD4D030827449AAC007AA4DD /* MaximPresenterObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaximPresenterObject.swift; sourceTree = "<group>"; };
-		DD6E0AEC27466CC50086D374 /* N005.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N005.mp4; sourceTree = "<group>"; };
-		DD6E0AED27466CC50086D374 /* N000.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N000.mp4; sourceTree = "<group>"; };
-		DD6E0AEE27466CC50086D374 /* M002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M002.jpg; sourceTree = "<group>"; };
-		DD6E0AEF27466CC50086D374 /* M007.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M007.jpg; sourceTree = "<group>"; };
-		DD6E0AF027466CC50086D374 /* N006.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N006.mp4; sourceTree = "<group>"; };
-		DD6E0AF127466CC50086D374 /* U000.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U000.WAV; sourceTree = "<group>"; };
-		DD6E0AF227466CC50086D374 /* N002.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N002.mp4; sourceTree = "<group>"; };
-		DD6E0AF327466CC50086D374 /* N001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N001.jpg; sourceTree = "<group>"; };
-		DD6E0AF427466CC50086D374 /* U001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U001.jpg; sourceTree = "<group>"; };
-		DD6E0AF527466CC50086D374 /* U002.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U002.WAV; sourceTree = "<group>"; };
-		DD6E0AF627466CC50086D374 /* M020.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M020.jpg; sourceTree = "<group>"; };
-		DD6E0AF727466CC50086D374 /* M016.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M016.jpg; sourceTree = "<group>"; };
-		DD6E0AF827466CC50086D374 /* N008.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N008.WAV; sourceTree = "<group>"; };
-		DD6E0AF927466CC50086D374 /* N002.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N002.WAV; sourceTree = "<group>"; };
-		DD6E0AFA27466CC50086D374 /* N004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N004.jpg; sourceTree = "<group>"; };
-		DD6E0AFB27466CC50086D374 /* M001.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M001.jpg; sourceTree = "<group>"; };
-		DD6E0AFC27466CC50086D374 /* N007.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N007.mp4; sourceTree = "<group>"; };
-		DD6E0AFD27466CC50086D374 /* N003.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N003.mp4; sourceTree = "<group>"; };
-		DD6E0AFE27466CC50086D374 /* U004.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U004.WAV; sourceTree = "<group>"; };
-		DD6E0AFF27466CC50086D374 /* U003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U003.jpg; sourceTree = "<group>"; };
-		DD6E0B0027466CC50086D374 /* N002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N002.jpg; sourceTree = "<group>"; };
-		DD6E0B0127466CC50086D374 /* M010.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M010.jpg; sourceTree = "<group>"; };
-		DD6E0B0227466CC50086D374 /* U001.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U001.WAV; sourceTree = "<group>"; };
-		DD6E0B0327466CC50086D374 /* N003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N003.jpg; sourceTree = "<group>"; };
-		DD6E0B0427466CC50086D374 /* U001.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U001.mp4; sourceTree = "<group>"; };
-		DD6E0B0527466CC50086D374 /* N008.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N008.jpg; sourceTree = "<group>"; };
-		DD6E0B0627466CC50086D374 /* M006.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M006.jpg; sourceTree = "<group>"; };
-		DD6E0B0727466CC50086D374 /* U003.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = U003.WAV; sourceTree = "<group>"; };
-		DD6E0B0827466CC50086D374 /* N005.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N005.WAV; sourceTree = "<group>"; };
-		DD6E0B0927466CC50086D374 /* M013.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M013.jpg; sourceTree = "<group>"; };
-		DD6E0B0A27466CC50086D374 /* N004.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N004.WAV; sourceTree = "<group>"; };
-		DD6E0B0B27466CC50086D374 /* M005.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M005.jpg; sourceTree = "<group>"; };
-		DD6E0B0C27466CC50086D374 /* U004.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U004.mp4; sourceTree = "<group>"; };
-		DD6E0B0D27466CC50086D374 /* M004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M004.jpg; sourceTree = "<group>"; };
-		DD6E0B0E27466CC50086D374 /* N000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N000.jpg; sourceTree = "<group>"; };
-		DD6E0B0F27466CC50086D374 /* M019.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M019.jpg; sourceTree = "<group>"; };
-		DD6E0B1027466CC50086D374 /* N001.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N001.WAV; sourceTree = "<group>"; };
-		DD6E0B1127466CC50086D374 /* M017.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M017.jpg; sourceTree = "<group>"; };
-		DD6E0B1227466CC50086D374 /* N008.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N008.mp4; sourceTree = "<group>"; };
-		DD6E0B1327466CC50086D374 /* N004.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N004.mp4; sourceTree = "<group>"; };
-		DD6E0B1427466CC50086D374 /* N000.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N000.WAV; sourceTree = "<group>"; };
-		DD6E0B1527466CC50086D374 /* U000.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U000.mp4; sourceTree = "<group>"; };
-		DD6E0B1627466CC50086D374 /* M009.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M009.jpg; sourceTree = "<group>"; };
-		DD6E0B1727466CC50086D374 /* U004.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U004.jpg; sourceTree = "<group>"; };
-		DD6E0B1827466CC50086D374 /* M000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M000.jpg; sourceTree = "<group>"; };
-		DD6E0B1927466CC50086D374 /* N001.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = N001.mp4; sourceTree = "<group>"; };
-		DD6E0B1A27466CC50086D374 /* N006.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N006.jpg; sourceTree = "<group>"; };
-		DD6E0B1B27466CC50086D374 /* M008.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M008.jpg; sourceTree = "<group>"; };
-		DD6E0B1C27466CC50086D374 /* U002.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U002.mp4; sourceTree = "<group>"; };
-		DD6E0B1D27466CC50086D374 /* N007.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N007.jpg; sourceTree = "<group>"; };
-		DD6E0B1E27466CC50086D374 /* N005.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = N005.jpg; sourceTree = "<group>"; };
-		DD6E0B1F27466CC50086D374 /* M014.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M014.jpg; sourceTree = "<group>"; };
-		DD6E0B2027466CC60086D374 /* N007.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N007.WAV; sourceTree = "<group>"; };
-		DD6E0B2127466CC60086D374 /* U003.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = U003.mp4; sourceTree = "<group>"; };
-		DD6E0B2227466CC60086D374 /* M011.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M011.jpg; sourceTree = "<group>"; };
-		DD6E0B2327466CC60086D374 /* M018.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M018.jpg; sourceTree = "<group>"; };
-		DD6E0B2427466CC60086D374 /* U000.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U000.jpg; sourceTree = "<group>"; };
-		DD6E0B2527466CC60086D374 /* M003.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M003.jpg; sourceTree = "<group>"; };
-		DD6E0B2627466CC60086D374 /* N006.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N006.WAV; sourceTree = "<group>"; };
-		DD6E0B2727466CC60086D374 /* M015.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M015.jpg; sourceTree = "<group>"; };
-		DD6E0B2827466CC60086D374 /* U002.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = U002.jpg; sourceTree = "<group>"; };
-		DD6E0B2927466CC60086D374 /* N003.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = N003.WAV; sourceTree = "<group>"; };
-		DD6E0B2A27466CC60086D374 /* M012.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = M012.jpg; sourceTree = "<group>"; };
 		DD6FD1F3274BBA2700568A4E /* MeDailyStaticsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeDailyStaticsCollectionViewCell.swift; sourceTree = "<group>"; };
 		DD6FD1F5274BCEB300568A4E /* Me+Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Me+Enums.swift"; sourceTree = "<group>"; };
 		DD6FD1F7274BD08400568A4E /* MeHeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeHeaderCollectionReusableView.swift; sourceTree = "<group>"; };
@@ -655,6 +564,69 @@
 				DD6E0B1727466CC50086D374 /* U004.jpg */,
 				DD6E0B0C27466CC50086D374 /* U004.mp4 */,
 				DD6E0AFE27466CC50086D374 /* U004.WAV */,
+				B401E387274E2EE60065A9EA /* M000.jpg */,
+				B401E386274E2EE60065A9EA /* M001.jpg */,
+				B401E385274E2EE60065A9EA /* M002.jpg */,
+				B401E381274E2EE60065A9EA /* M003.jpg */,
+				B401E383274E2EE60065A9EA /* M004.jpg */,
+				B401E390274E2EE70065A9EA /* M005.jpg */,
+				B401E3F7274E4E160065A9EA /* U003.jpg */,
+				B401E3F9274E4E160065A9EA /* U003.mp4 */,
+				B401E3F8274E4E160065A9EA /* U004.jpg */,
+				B401E3F6274E4E160065A9EA /* U004.mp4 */,
+				B401E391274E2EE70065A9EA /* M006.jpg */,
+				B401E3AC274E2F0B0065A9EA /* N000.jpg */,
+				B401E3AB274E2F0B0065A9EA /* N000.mp4 */,
+				B401E3A9274E2F0B0065A9EA /* N000.WAV */,
+				B401E3A7274E2F0B0065A9EA /* N001.jpg */,
+				B401E3C9274E2F910065A9EA /* D003.jpg */,
+				B401E3CA274E2F920065A9EA /* D004.jpg */,
+				B401E3D5274E2FE30065A9EA /* N003.jpg */,
+				B401E3CD274E2FE20065A9EA /* N003.mp4 */,
+				B401E3D3274E2FE30065A9EA /* N004.jpg */,
+				B401E3CF274E2FE20065A9EA /* N004.mp4 */,
+				B401E3D1274E2FE20065A9EA /* N005.jpg */,
+				B401E3FE274E4E700065A9EA /* U003.WAV */,
+				B401E3D2274E2FE20065A9EA /* N005.mp4 */,
+				B401E3D0274E2FE20065A9EA /* N006.jpg */,
+				B401E3D4274E2FE30065A9EA /* N006.mp4 */,
+				B401E3E9274E30640065A9EA /* U005.jpg */,
+				B401E3D6274E2FE30065A9EA /* N007.jpg */,
+				B401E3CE274E2FE20065A9EA /* N007.mp4 */,
+				B401E3AA274E2F0B0065A9EA /* N001.mp4 */,
+				B401E3A8274E2F0B0065A9EA /* N001.WAV */,
+				B401E3AE274E2F0B0065A9EA /* N002.jpg */,
+				B401E3AF274E2F0B0065A9EA /* N002.mp4 */,
+				B401E3AD274E2F0B0065A9EA /* N002.WAV */,
+				B401E3BA274E2F540065A9EA /* U001.jpg */,
+				B401E3BB274E2F540065A9EA /* U001.mp4 */,
+				B401E3B9274E2F540065A9EA /* U001.WAV */,
+				B401E382274E2EE60065A9EA /* M007.jpg */,
+				B401E388274E2EE60065A9EA /* M008.jpg */,
+				B401E384274E2EE60065A9EA /* M009.jpg */,
+				B401E37E274E2EE60065A9EA /* M010.jpg */,
+				B401E389274E2EE60065A9EA /* M011.jpg */,
+				B401E38A274E2EE70065A9EA /* M012.jpg */,
+				B401E380274E2EE60065A9EA /* M013.jpg */,
+				B401E38F274E2EE70065A9EA /* M014.jpg */,
+				B401E38C274E2EE70065A9EA /* M015.jpg */,
+				B401E37D274E2EE60065A9EA /* M016.jpg */,
+				B401E38B274E2EE70065A9EA /* M017.jpg */,
+				B401E37F274E2EE60065A9EA /* M018.jpg */,
+				B401E38D274E2EE70065A9EA /* M019.jpg */,
+				B401E38E274E2EE70065A9EA /* M020.jpg */,
+				B401E3F1274E31A40065A9EA /* U000.jpg */,
+				B401E3F4274E31BD0065A9EA /* U004.WAV */,
+				B401E3F0274E31A40065A9EA /* U000.mp4 */,
+				B401E374274E2ED60065A9EA /* D000.jpg */,
+				B401E372274E2ED60065A9EA /* D000.mp3 */,
+				B401E3EC274E30D20065A9EA /* U002.jpg */,
+				B401E3ED274E30D20065A9EA /* U002.mp4 */,
+				B401E373274E2ED60065A9EA /* D001.jpg */,
+				B401E3EB274E30850065A9EA /* U005.mp4 */,
+				B401E375274E2ED60065A9EA /* D001.mp3 */,
+				B401E376274E2ED60065A9EA /* D002.jpg */,
+				B401E371274E2ED60065A9EA /* D002.mp3 */,
 			);
 			path = Resource;
 			sourceTree = "<group>";
@@ -1302,74 +1274,61 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B401E3FF274E4E700065A9EA /* U003.WAV in Resources */,
+				B401E399274E2EE70065A9EA /* M009.jpg in Resources */,
 				DD3902DD272FCA12009ECA82 /* LaunchScreen.storyboard in Resources */,
-				B4E4210927460BBB00C39545 /* M017.jpg in Resources */,
-				B4E420E127460BBB00C39545 /* M000.jpg in Resources */,
+				B401E3DB274E2FE30065A9EA /* N005.jpg in Resources */,
+				B401E3A6274E2EE70065A9EA /* M006.jpg in Resources */,
+				B401E3A5274E2EE70065A9EA /* M005.jpg in Resources */,
+				B401E3A0274E2EE70065A9EA /* M017.jpg in Resources */,
+				B401E39C274E2EE70065A9EA /* M000.jpg in Resources */,
+				B401E3DC274E2FE30065A9EA /* N005.mp4 in Resources */,
+				B401E39B274E2EE70065A9EA /* M001.jpg in Resources */,
+				B401E3B0274E2F0B0065A9EA /* N001.jpg in Resources */,
+				B401E3EF274E30D20065A9EA /* U002.mp4 in Resources */,
 				918D19A5273D21B300A13954 /* sea.mp4 in Resources */,
-				B4E420F527460BBB00C39545 /* U000.mp4 in Resources */,
-				B4E420FC27460BBB00C39545 /* M013.jpg in Resources */,
-				B4E420E527460BBB00C39545 /* U002.mp4 in Resources */,
-				B4E4210127460BBB00C39545 /* U002.WAV in Resources */,
-				B4E420E927460BBB00C39545 /* U001.jpg in Resources */,
-				B4E4210727460BBB00C39545 /* N004.jpg in Resources */,
-				B4E420E627460BBB00C39545 /* N002.jpg in Resources */,
-				B4E420F427460BBB00C39545 /* U004.mp4 in Resources */,
-				B4E420DB27460BBB00C39545 /* M010.jpg in Resources */,
-				B4E4210527460BBB00C39545 /* M015.jpg in Resources */,
-				B4E420EC27460BBB00C39545 /* M001.jpg in Resources */,
-				B4E420FE27460BBB00C39545 /* M004.jpg in Resources */,
+				B401E37C274E2ED60065A9EA /* D002.jpg in Resources */,
+				B401E39E274E2EE70065A9EA /* M011.jpg in Resources */,
+				B401E3DA274E2FE30065A9EA /* N006.jpg in Resources */,
+				B401E377274E2ED60065A9EA /* D002.mp3 in Resources */,
 				91D02279273CDF610073EA2A /* DummyData.json in Resources */,
-				B4E420E227460BBB00C39545 /* N004.WAV in Resources */,
-				B4E420E727460BBB00C39545 /* M016.jpg in Resources */,
-				B4E420F027460BBB00C39545 /* N000.mp4 in Resources */,
-				B4E420EE27460BBB00C39545 /* M007.jpg in Resources */,
-				B4E420FB27460BBB00C39545 /* N000.WAV in Resources */,
-				B4E420E427460BBB00C39545 /* U004.WAV in Resources */,
-				B4E420FA27460BBB00C39545 /* N004.mp4 in Resources */,
-				B4E420E827460BBB00C39545 /* M005.jpg in Resources */,
-				B4E420FD27460BBB00C39545 /* M011.jpg in Resources */,
-				B4E420F927460BBB00C39545 /* U000.WAV in Resources */,
-				B4E420D927460BBB00C39545 /* M014.jpg in Resources */,
-				B4E4210227460BBB00C39545 /* U003.WAV in Resources */,
-				B4E4210327460BBB00C39545 /* U003.jpg in Resources */,
-				B4E420EB27460BBB00C39545 /* U001.WAV in Resources */,
-				B4E420E027460BBB00C39545 /* M020.jpg in Resources */,
-				B4E420E327460BBB00C39545 /* U001.mp4 in Resources */,
-				B4E4210B27460BBB00C39545 /* M019.jpg in Resources */,
-				B4E420F727460BBB00C39545 /* N002.mp4 in Resources */,
-				B4E4210627460BBB00C39545 /* N001.mp4 in Resources */,
-				B4E4210827460BBB00C39545 /* N001.WAV in Resources */,
-				B4E420DF27460BBB00C39545 /* N000.jpg in Resources */,
-				B4E4210A27460BBB00C39545 /* N002.WAV in Resources */,
-				B4E420F327460BBB00C39545 /* M018.jpg in Resources */,
-				B4E420F627460BBB00C39545 /* M002.jpg in Resources */,
-				B4E4210027460BBB00C39545 /* U004.jpg in Resources */,
-				B4E420F827460BBB00C39545 /* M006.jpg in Resources */,
-				B4E4210427460BBB00C39545 /* M009.jpg in Resources */,
-				B4E420DA27460BBB00C39545 /* N003.mp4 in Resources */,
+				B401E395274E2EE70065A9EA /* M013.jpg in Resources */,
+				B401E3CC274E2F920065A9EA /* D004.jpg in Resources */,
+				B401E3FD274E4E160065A9EA /* U003.mp4 in Resources */,
+				B401E3BC274E2F540065A9EA /* U001.WAV in Resources */,
+				B401E3B8274E2F0B0065A9EA /* N002.mp4 in Resources */,
+				B401E3B3274E2F0B0065A9EA /* N001.mp4 in Resources */,
+				B401E3DF274E2FE30065A9EA /* N003.jpg in Resources */,
+				B401E3CB274E2F920065A9EA /* D003.jpg in Resources */,
+				B401E3DD274E2FE30065A9EA /* N004.jpg in Resources */,
 				B490FE30274C9C2B008A4454 /* Assets.xcassets in Resources */,
-				B4E420FF27460BBB00C39545 /* M003.jpg in Resources */,
-				B4E420DE27460BBB00C39545 /* U000.jpg in Resources */,
-				B4E420F127460BBB00C39545 /* U002.jpg in Resources */,
-				B4E420EF27460BBB00C39545 /* U003.mp4 in Resources */,
-				B4E420DC27460BBB00C39545 /* M008.jpg in Resources */,
-				B4E420DD27460BBB00C39545 /* N003.WAV in Resources */,
-				B4E420ED27460BBB00C39545 /* N001.jpg in Resources */,
+				B401E3F5274E31BD0065A9EA /* U004.WAV in Resources */,
+				B401E3FB274E4E160065A9EA /* U003.jpg in Resources */,
+				B401E396274E2EE70065A9EA /* M003.jpg in Resources */,
+				B401E3F3274E31A40065A9EA /* U000.jpg in Resources */,
 				DF71D22F2734455600CD980E /* GoogleService-Info.plist in Resources */,
-				B4E420F227460BBB00C39545 /* M012.jpg in Resources */,
-				B4E420EA27460BBB00C39545 /* N003.jpg in Resources */,
-				DD6E0B6827466CC60086D374 /* N003.WAV in Resources */,
-				DD6E0B3227466CC60086D374 /* N001.jpg in Resources */,
-				DD6E0B4927466CC60086D374 /* N004.WAV in Resources */,
-				DD6E0B4227466CC60086D374 /* N003.jpg in Resources */,
+				B401E378274E2ED60065A9EA /* D000.mp3 in Resources */,
 				DD3902DD272FCA12009ECA82 /* LaunchScreen.storyboard in Resources */,
-				DD6E0B4E27466CC60086D374 /* M019.jpg in Resources */,
+				B401E3E0274E2FE30065A9EA /* N007.jpg in Resources */,
+				B401E37A274E2ED60065A9EA /* D000.jpg in Resources */,
+				B401E398274E2EE70065A9EA /* M004.jpg in Resources */,
+				B401E3B2274E2F0B0065A9EA /* N000.WAV in Resources */,
+				B401E39A274E2EE70065A9EA /* M002.jpg in Resources */,
+				B401E3B4274E2F0B0065A9EA /* N000.mp4 in Resources */,
+				B401E379274E2ED60065A9EA /* D001.jpg in Resources */,
+				B401E3D9274E2FE30065A9EA /* N004.mp4 in Resources */,
+				B401E394274E2EE70065A9EA /* M018.jpg in Resources */,
+				B401E3BE274E2F540065A9EA /* U001.mp4 in Resources */,
+				B401E392274E2EE70065A9EA /* M016.jpg in Resources */,
+				B401E3EA274E30640065A9EA /* U005.jpg in Resources */,
+				B401E39F274E2EE70065A9EA /* M012.jpg in Resources */,
+				B401E3EE274E30D20065A9EA /* U002.jpg in Resources */,
+				B401E39D274E2EE70065A9EA /* M008.jpg in Resources */,
+				B401E3BD274E2F540065A9EA /* U001.jpg in Resources */,
 				918D19A5273D21B300A13954 /* sea.mp4 in Resources */,
-				DD6E0B4F27466CC60086D374 /* N001.WAV in Resources */,
-				DD6E0B6227466CC60086D374 /* M018.jpg in Resources */,
-				DD6E0B6427466CC60086D374 /* M003.jpg in Resources */,
-				DD6E0B6327466CC60086D374 /* U000.jpg in Resources */,
-				DD6E0B3427466CC60086D374 /* U002.WAV in Resources */,
+				B401E3D7274E2FE30065A9EA /* N003.mp4 in Resources */,
+				B401E37B274E2ED60065A9EA /* D001.mp3 in Resources */,
+				B401E397274E2EE70065A9EA /* M007.jpg in Resources */,
 				91D02279273CDF610073EA2A /* DummyData.json in Resources */,
 				DD6E0B6627466CC60086D374 /* M015.jpg in Resources */,
 				DD6E0B5427466CC60086D374 /* U000.mp4 in Resources */,
@@ -1411,9 +1370,21 @@
 				DD6E0B3F27466CC60086D374 /* N002.jpg in Resources */,
 				DD6E0B5B27466CC60086D374 /* U002.mp4 in Resources */,
 				DD6E0B4627466CC60086D374 /* U003.WAV in Resources */,
+				B401E3D8274E2FE30065A9EA /* N007.mp4 in Resources */,
+				B401E393274E2EE70065A9EA /* M010.jpg in Resources */,
+				B401E3FC274E4E160065A9EA /* U004.jpg in Resources */,
+				B401E3A3274E2EE70065A9EA /* M020.jpg in Resources */,
+				B401E3A1274E2EE70065A9EA /* M015.jpg in Resources */,
+				B401E3A2274E2EE70065A9EA /* M019.jpg in Resources */,
 				DF71D22F2734455600CD980E /* GoogleService-Info.plist in Resources */,
-				DD6E0B3827466CC60086D374 /* N002.WAV in Resources */,
-				DD6E0B3627466CC60086D374 /* M016.jpg in Resources */,
+				B401E3B7274E2F0B0065A9EA /* N002.jpg in Resources */,
+				B401E3FA274E4E160065A9EA /* U004.mp4 in Resources */,
+				B401E3A4274E2EE70065A9EA /* M014.jpg in Resources */,
+				B401E3F2274E31A40065A9EA /* U000.mp4 in Resources */,
+				B401E3B1274E2F0B0065A9EA /* N001.WAV in Resources */,
+				B401E3DE274E2FE30065A9EA /* N006.mp4 in Resources */,
+				B401E3B5274E2F0B0065A9EA /* N000.jpg in Resources */,
+				B401E3B6274E2F0B0065A9EA /* N002.WAV in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JipJung/JipJung/Dummy/DummyData.json
+++ b/JipJung/JipJung/Dummy/DummyData.json
@@ -66,6 +66,45 @@
       "audioFileName": "N004.WAV"
     },
     {
+      "id": "N005",
+      "name": "작은 폭포",
+      "explanation": "바위위로 흐르는 폭포",
+      "maxim": "곧은 소리는 소리이다.\n곧은 소리는 곧은 소리를 부른다.",
+      "speaker": "김수영",
+      "color": "553830",
+      "mode": 0,
+      "tag": "All/Nature/Relax/Focus",
+      "thumbnailImageFileName": "N005.jpg",
+      "videoFileName": "N005.mp4",
+      "audioFileName": "N005.WAV"
+    },
+    {
+      "id": "N006",
+      "name": "아침 햇살",
+      "explanation": "이른 아침 새소리",
+      "maxim": "하루를 산다는 건 그물을 싣고\n바다를 향해 떠나는 싱싱한 희망이야.",
+      "speaker": "조희선",
+      "color": "FF7F00",
+      "mode": 0,
+      "tag": "All/Nature/Relax/Focus",
+      "thumbnailImageFileName": "N006.jpg",
+      "videoFileName": "N006.mp4",
+      "audioFileName": "N006.WAV"
+    },
+    {
+      "id": "N007",
+      "name": "계곡",
+      "explanation": "단풍이 떠있는 가을의 계곡",
+      "maxim": "보고 싶은 사람 때문에/n먼 산에 단풍 물드는 사랑",
+      "speaker": "안도현",
+      "color": "964B00",
+      "mode": 0,
+      "tag": "All/Nature/Relax",
+      "thumbnailImageFileName": "N007.jpg",
+      "videoFileName": "N007.mp4",
+      "audioFileName": "N007.WAV"
+    },
+    {
       "id": "U000",
       "name": "가로등",
       "explanation": "비를 비추는 가로등",
@@ -129,6 +168,84 @@
       "thumbnailImageFileName": "U004.jpg",
       "videoFileName": "U004.mp4",
       "audioFileName": "U004.WAV"
+    },
+    {
+      "id": "U005",
+      "name": "사물놀이",
+      "explanation": "신명나는 사물놀이",
+      "maxim": "한 잔 먹세그려 또 한잔 먹세그려./n꽃 꺾어 술잔 세며 한없이 먹세그려.",
+      "speaker": "송강 정철",
+      "color": "D070FB",
+      "mode": 0,
+      "tag": "All/Urban/Relax",
+      "thumbnailImageFileName": "U005.jpg",
+      "videoFileName": "U005.mp4",
+      "audioFileName": "U005.WAV"
+    },
+    {
+      "id": "D000",
+      "name": "TechHouse Mix",
+      "explanation": "",
+      "maxim": "",
+      "speaker": "",
+      "color": "000000",
+      "mode": 1,
+      "tag": "All/Urban/Relax/Club",
+      "thumbnailImageFileName": "D000.jpg",
+      "videoFileName": "D000.mp4",
+      "audioFileName": "D000.mp3"
+    },
+    {
+      "id": "D001",
+      "name": "JazzHouse Mix",
+      "explanation": "",
+      "maxim": "",
+      "speaker": "",
+      "color": "000000",
+      "mode": 1,
+      "tag": "All/Urban/Cafe/Lounge/Club",
+      "thumbnailImageFileName": "D001.jpg",
+      "videoFileName": "D001.mp4",
+      "audioFileName": "D001.mp3"
+    },
+    {
+      "id": "D002",
+      "name": "JackinHouse Mix",
+      "explanation": "",
+      "maxim": "",
+      "speaker": "",
+      "color": "000000",
+      "mode": 1,
+      "tag": "All/Urban/Cafe/Lounge/Club",
+      "thumbnailImageFileName": "D002.jpg",
+      "videoFileName": "D002.mp4",
+      "audioFileName": "D002.mp3"
+    },
+    {
+      "id": "D003",
+      "name": "House Mix",
+      "explanation": "",
+      "maxim": "",
+      "speaker": "",
+      "color": "000000",
+      "mode": 1,
+      "tag": "All/Urban/Relax/Lounge/Club",
+      "thumbnailImageFileName": "D003.jpg",
+      "videoFileName": "D003.mp4",
+      "audioFileName": "D003.mp3"
+    },
+    {
+      "id": "D004",
+      "name": "TechHouse Mix",
+      "explanation": "",
+      "maxim": "",
+      "speaker": "",
+      "color": "000000",
+      "mode": 1,
+      "tag": "All/Urban/Relax/Club",
+      "thumbnailImageFileName": "D004.jpg",
+      "videoFileName": "D004.mp4",
+      "audioFileName": "D004.mp3"
     }
   ],
   "PlayHistory": [
@@ -181,9 +298,22 @@
     },
     {
       "id": "N002"
-    }
-  ],
-  "DarknessMedia": [
+    },
+    {
+      "id": "N003"
+    },
+    {
+      "id": "N004"
+    },
+    {
+      "id": "N005"
+    },
+    {
+      "id": "N006"
+    },
+    {
+      "id": "N007"
+    },
     {
       "id": "U000"
     },
@@ -192,6 +322,32 @@
     },
     {
       "id": "U002"
+    },
+    {
+      "id": "U003"
+    },
+    {
+      "id": "U004"
+    },
+    {
+      "id": "U005"
+    }
+  ],
+  "DarknessMedia": [
+    {
+      "id": "D000"
+    },
+    {
+      "id": "D001"
+    },
+    {
+      "id": "D002"
+    },
+    {
+      "id": "D003"
+    },
+    {
+      "id": "D004"
     }
   ]
   ,

--- a/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
+++ b/JipJung/JipJung/UI/Explore/Main/Views/ExploreViewController.swift
@@ -126,7 +126,7 @@ final class ExploreViewController: UIViewController {
         scrollContentView.addSubview(soundCollectionView)
         soundCollectionView.snp.makeConstraints {
             $0.top.equalTo(soundTagCollectionView.snp.bottom).offset(20)
-            $0.height.equalTo(1200)
+            $0.height.equalTo(2400)
             $0.leading.trailing.bottom.equalToSuperview()
         }
     }

--- a/JipJung/JipJung/UI/Home/Main/Views/HomeViewController.swift
+++ b/JipJung/JipJung/UI/Home/Main/Views/HomeViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import RxCocoa
 import RxSwift
 import SnapKit
+import SpriteKit
 
 class HomeViewController: UIViewController {
     private lazy var mainScrollView: UIScrollView = {
@@ -68,6 +69,17 @@ class HomeViewController: UIViewController {
         return collectionView
     }()
     private lazy var touchTransferView = TouchTransferView()
+    private lazy var clubView: SKView = {
+        let clubView = SKView()
+        return clubView
+    }()
+    private lazy var clubScene: SKScene = {
+        let clubScene = ClubSKScene()
+        clubScene.size = CGSize(width: view.frame.width,
+                                height: view.frame.height)
+        clubScene.scaleMode = .fill
+        return clubScene
+    }()
     
     private let viewModel: HomeViewModel = HomeViewModel()
     private let disposeBag = DisposeBag()
@@ -326,6 +338,24 @@ class HomeViewController: UIViewController {
         }
     }
     
+    private func configureClubView() {
+        carouselView.addSubview(clubView)
+        clubView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.size.equalToSuperview()
+        }
+        clubView.presentScene(clubScene)
+    }
+    
+    private func configureDarkMode() {
+        configureClubView()
+    }
+    
+    private func dismissDarkMode() {
+        clubScene.removeFromParent()
+        clubView.removeFromSuperview()
+    }
+    
     private func bindUI() {
         bindUIWithView()
         bindUIWithViewModel()
@@ -399,6 +429,18 @@ class HomeViewController: UIViewController {
                     alpha: 1.0
                 )
             }.disposed(by: disposeBag)
+        
+        ApplicationMode.shared.mode
+            .bind { [weak self] in
+                guard let self = self else { return }
+                switch $0 {
+                case .bright:
+                    self.dismissDarkMode()
+                case .dark:
+                    self.configureDarkMode()
+                }
+            }
+            .disposed(by: disposeBag)
     }
     
     private func mediaPlayButtonTouched() -> Single<Bool> {

--- a/JipJung/JipJung/UI/Home/Main/Views/HomeViewController.swift
+++ b/JipJung/JipJung/UI/Home/Main/Views/HomeViewController.swift
@@ -69,10 +69,7 @@ class HomeViewController: UIViewController {
         return collectionView
     }()
     private lazy var touchTransferView = TouchTransferView()
-    private lazy var clubView: SKView = {
-        let clubView = SKView()
-        return clubView
-    }()
+    private let clubView: SKView = SKView()
     private lazy var clubScene: SKScene = {
         let clubScene = ClubSKScene()
         clubScene.size = CGSize(width: view.frame.width,


### PR DESCRIPTION
# 작업 내용
- 기본 에셋에 다크 모드 사진/영상/음원 추가
- 더미 데이터 갱신
- 홈 화면 clubView 추가

# 관련된 이슈 번호
close #143 

# 스크린 샷(optional)
https://user-images.githubusercontent.com/81892038/143265912-c791064d-869c-44b4-bc18-7e13c8810c75.mp4
