### PR TITLE
✨ 오늘 날짜부터 데이터를 보여주도록 변경

### DIFF
--- a/JipJung/JipJung/Data/Repositories/MaximListRepository.swift
+++ b/JipJung/JipJung/Data/Repositories/MaximListRepository.swift
@@ -12,8 +12,8 @@ import RxSwift
 final class MaximListRepository {
     private let localDBManager = RealmDBManager.shared
     
-    func fetchAllMaximList() -> Single<[Maxim]> {
-        return localDBManager.requestAllMaximList()
+    func fetchAllMaximList(from date: Date) -> Single<[Maxim]> {
+        return localDBManager.search(ofType: Maxim.self, with: NSPredicate(format: "date < %@", date as CVarArg))
     }
     
     func fetchFavoriteMaximList() -> Single<[Maxim]> {

--- a/JipJung/JipJung/Domain/UseCases/MaximListUseCase.swift
+++ b/JipJung/JipJung/Domain/UseCases/MaximListUseCase.swift
@@ -15,8 +15,17 @@ final class MaximListUseCase {
     init(maximListRepository: MaximListRepository = MaximListRepository()) {
         self.maximListRepository = maximListRepository
     }
-    func fetchAllMaximList() -> Single<[Maxim]> {
-        return maximListRepository.fetchAllMaximList()
+    func fetchMaximList() -> Single<[Maxim]> {
+        return maximListRepository.fetchAllMaximList(from: makeTomorrow()).map {
+            return $0.dropLast($0.count % 7)
+        }
+    }
+    
+    private func makeTomorrow() -> Date {
+        let date = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter.date(from: [date.year, date.month, date.day + 1].map({"\($0)"}).joined(separator: "-")) ?? Date(timeIntervalSinceNow: 86400)
     }
     
     func fetchFavoriteMaximList() -> Single<[Maxim]> {

--- a/JipJung/JipJung/UI/Home/Maxim/ViewModels/MaximViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Maxim/ViewModels/MaximViewModel.swift
@@ -31,14 +31,16 @@ final class MaximViewModel: MaximViewModelInput, MaximViewModelOutput {
     let selectedDate = BehaviorRelay<IndexPath>(value: IndexPath(item: 0, section: 0))
     private var disposeBag = DisposeBag()
     private let maximListUseCase: MaximListUseCase
+    private let today = Date()
     
     init(maximListUseCase: MaximListUseCase = MaximListUseCase()) {
         self.maximListUseCase = maximListUseCase
     }
 
     func fetchMaximList() {
-        maximListUseCase.fetchAllMaximList()
-            .map({ $0.map({ MaximPresenterObject(maxim: $0) })})
+        maximListUseCase.fetchMaximList()
+            .map({
+                $0.map({ MaximPresenterObject(maxim: $0) })})
             .subscribe { [weak self] in
                 self?.maximList.accept($0)
             }

--- a/JipJung/JipJung/UI/Home/Maxim/Views/MaximCalendarHeaderCollectionViewCell.swift
+++ b/JipJung/JipJung/UI/Home/Maxim/Views/MaximCalendarHeaderCollectionViewCell.swift
@@ -12,15 +12,15 @@ class MaximCalendarHeaderCollectionViewCell: UICollectionViewCell {
         let weekdayLabel = UILabel()
         weekdayLabel.font = .systemFont(ofSize: 20)
         weekdayLabel.textColor = .gray
-        weekdayLabel.text = "Today"
+        weekdayLabel.text = " "
         return weekdayLabel
     }()
     
     private lazy var dayButton: UIButton = {
         let dayButton = UIButton()
-        dayButton.setBackgroundImage(UIImage(systemName: "calendar"), for: .normal)
         dayButton.isUserInteractionEnabled = false
         dayButton.makeCircle()
+        dayButton.backgroundColor = .black
         return dayButton
     }()
 
@@ -40,12 +40,21 @@ class MaximCalendarHeaderCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    private(set) lazy var indicatorPointView: UIView = {
+    private lazy var indicatorPointView: UIView = {
         let indicatorPointView = UIView()
         indicatorPointView.backgroundColor = .red
         indicatorPointView.isHidden = true
         return indicatorPointView
     }()
+    
+    var indicatorPointViewIsHidden: Bool {
+        get {
+            indicatorPointView.isHidden
+        }
+        set {
+            indicatorPointView.isHidden = newValue
+        }
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/JipJung/JipJung/UI/Home/Maxim/Views/MaximViewController.swift
+++ b/JipJung/JipJung/UI/Home/Maxim/Views/MaximViewController.swift
@@ -138,7 +138,9 @@ final class MaximViewController: UIViewController {
     }
     
     private func bindMaximCollectionView() {
-        viewModel.maximList.bind(to: maximCollectionView.rx.items(cellIdentifier: MaximCollectionViewCell.identifier)) { index, maxim, cell in
+        viewModel.maximList
+            .map({$0.compactMap({$0})})
+            .bind(to: maximCollectionView.rx.items(cellIdentifier: MaximCollectionViewCell.identifier)) { index, maxim, cell in
             guard let cell = cell as? MaximCollectionViewCell else {
                 return
             }
@@ -174,13 +176,13 @@ final class MaximViewController: UIViewController {
             guard let cell = cell as? MaximCalendarHeaderCollectionViewCell else {
                 return
             }
-            cell.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
             cell.dayLabel.text = maxim.day
             cell.weekdayLabel.text = maxim.weekDay
             cell.dayButtonImageName = maxim.thumbnailImageAssetPath
             if self?.viewModel.selectedDate.value.item == index {
-                cell.indicatorPointView.isHidden = false
+                cell.indicatorPointViewIsHidden = false
             }
+            cell.transform = CGAffineTransform(rotationAngle: CGFloat.pi)
         }
         .disposed(by: disposeBag)
         
@@ -188,13 +190,15 @@ final class MaximViewController: UIViewController {
         let previousObservable = dateObservable
         let currentObservable = dateObservable.skip(1)
         
-        Observable.zip(previousObservable, currentObservable).bind(onNext: { [weak self] (prev, cur) in
+        Observable.zip(previousObservable, currentObservable)
+            .debug()
+            .bind(onNext: { [weak self] (prev, cur) in
             let previousCell =
             self?.calendarHeaderCollectionView.cellForItem(at: prev) as? MaximCalendarHeaderCollectionViewCell
             let currentCell =
             self?.calendarHeaderCollectionView.cellForItem(at: cur) as? MaximCalendarHeaderCollectionViewCell
-            previousCell?.indicatorPointView.isHidden = true
-            currentCell?.indicatorPointView.isHidden = false
+            previousCell?.indicatorPointViewIsHidden = true
+            currentCell?.indicatorPointViewIsHidden = false
         })
             .disposed(by: disposeBag)
         // TODO: Today관련 bind


### PR DESCRIPTION
# 작업 내용
- 기존 데이터는 12월 11일을 기준으로 보여주는데, 당일날짜부터 보여주도록 변경했습니다.
- 일 월 화 수 목 금 토 를 한 사이클로 잡아서 사용하고 싶었는데, 하다가 실패했습니다...
- 여전히 빨간포인터가 마음대로 돌아다니는 버그가 있습니다.
- asset은 추가해야할 것 같습니다.

# 관련된 이슈 번호

