### PR TITLE
✨ 집중모드 종료시 알림, 햅틱 피드백 추가

### DIFF
--- a/JipJung/JipJung.xcodeproj/project.pbxproj
+++ b/JipJung/JipJung.xcodeproj/project.pbxproj
@@ -190,6 +190,8 @@
 		DF05FD3A274D7FD1006C8689 /* breath.WAV in Resources */ = {isa = PBXBuildFile; fileRef = DF05FD39274D7FD1006C8689 /* breath.WAV */; };
 		DF08B1DD2737F5010066518B /* RemoteServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF08B1DC2737F5010066518B /* RemoteServiceProvider.swift */; };
 		DF09E9B52741FAC700F5F739 /* Utils+Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF09E9B42741FAC700F5F739 /* Utils+Enums.swift */; };
+		DF1496A9274F5B990053776F /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1496A8274F5B990053776F /* PushNotificationManager.swift */; };
+		DF1496AB274F83BA0053776F /* FeedbackGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1496AA274F83BA0053776F /* FeedbackGenerator.swift */; };
 		DF1722B22740FD2300F06140 /* ApplicationLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1722B12740FD2300F06140 /* ApplicationLaunch.swift */; };
 		DF1722B42741013600F06140 /* LocalDBMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1722B32741013600F06140 /* LocalDBMigrator.swift */; };
 		DF1722B72741036C00F06140 /* BundleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1722B62741036C00F06140 /* BundleManager.swift */; };
@@ -417,6 +419,8 @@
 		DF05FD39274D7FD1006C8689 /* breath.WAV */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = breath.WAV; sourceTree = "<group>"; };
 		DF08B1DC2737F5010066518B /* RemoteServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServiceProvider.swift; sourceTree = "<group>"; };
 		DF09E9B42741FAC700F5F739 /* Utils+Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Utils+Enums.swift"; sourceTree = "<group>"; };
+		DF1496A8274F5B990053776F /* PushNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManager.swift; sourceTree = "<group>"; };
+		DF1496AA274F83BA0053776F /* FeedbackGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackGenerator.swift; sourceTree = "<group>"; };
 		DF1722B12740FD2300F06140 /* ApplicationLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLaunch.swift; sourceTree = "<group>"; };
 		DF1722B32741013600F06140 /* LocalDBMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBMigrator.swift; sourceTree = "<group>"; };
 		DF1722B62741036C00F06140 /* BundleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleManager.swift; sourceTree = "<group>"; };
@@ -1001,6 +1005,8 @@
 				DF1722B12740FD2300F06140 /* ApplicationLaunch.swift */,
 				DF1722B32741013600F06140 /* LocalDBMigrator.swift */,
 				B490FDBD274B771F008A4454 /* ApplicationMode.swift */,
+				DF1496A8274F5B990053776F /* PushNotificationManager.swift */,
+				DF1496AA274F83BA0053776F /* FeedbackGenerator.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1379,6 +1385,7 @@
 				DDB92B9D2737BD5E00EE26F0 /* UIView+Extension.swift in Sources */,
 				DD7CDCB4274D1E66005ADF35 /* LoadFocusTimeUseCase.swift in Sources */,
 				DF1722B72741036C00F06140 /* BundleManager.swift in Sources */,
+				DF1496AB274F83BA0053776F /* FeedbackGenerator.swift in Sources */,
 				DDB5CEB32733752D00E8F9EB /* FavoriteMedia.swift in Sources */,
 				DDB92BB0273A263100EE26F0 /* MusicCollectionViewCell.swift in Sources */,
 				DDB5CEB32733752D00E8F9EB /* FavoriteMedia.swift in Sources */,
@@ -1454,6 +1461,7 @@
 				DD4D030527425611007AA4DD /* UILabel+Extension.swift in Sources */,
 				DDB5CEBE2733A49A00E8F9EB /* RealmDBManager.swift in Sources */,
 				DD6FD1F8274BD08400568A4E /* MeHeaderCollectionReusableView.swift in Sources */,
+				DF1496A9274F5B990053776F /* PushNotificationManager.swift in Sources */,
 				91655858273B773400C55CDC /* MaximListUseCase.swift in Sources */,
 				91EA47C6273846A800780C3E /* BlurCircleButton.swift in Sources */,
 				B4015CD42739151B006BD14A /* PlayHistoryViewController.swift in Sources */,

--- a/JipJung/JipJung/Application/AppDelegate.swift
+++ b/JipJung/JipJung/Application/AppDelegate.swift
@@ -11,11 +11,13 @@ import Firebase
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    let applicationLaunch = ApplicationLaunch()
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         #if DEBUG
-        try? ApplicationLaunch().makeDebugLaunch()
+        try? applicationLaunch.makeDebugLaunch()
         #endif
-        ApplicationLaunch().start()
+        applicationLaunch.start()
 
         return true
     }
@@ -33,5 +35,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
 }

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
@@ -29,11 +29,6 @@ protocol PomodoroFocusViewModelOutput {
     var mode: BehaviorRelay<PomodoroMode> { get }
 }
 
-enum PomodoroPresentationStatus {
-    case working
-    case breaking
-}
-
 final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusViewModelOutput {
     var clockTime: BehaviorRelay<Int> = BehaviorRelay<Int>(value: 0)
     var isFocusRecordSaved: BehaviorRelay<Bool> = BehaviorRelay<Bool>(value: false)
@@ -91,7 +86,7 @@ final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusVi
             } onFailure: { [weak self] _ in
                 self?.isFocusRecordSaved.accept(false)
             }
-            .disposed(by: disposeBag) // runningStateDisposeBag
+            .disposed(by: disposeBag) // TODO: disposeBag 2개 쓰는 것 같은데 하나만 써도 되지 않을까요?
     }
     
     func changeMode() {

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
@@ -29,6 +29,11 @@ protocol PomodoroFocusViewModelOutput {
     var mode: BehaviorRelay<PomodoroMode> { get }
 }
 
+enum PomodoroPresentationStatus {
+    case working
+    case breaking
+}
+
 final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusViewModelOutput {
     var clockTime: BehaviorRelay<Int> = BehaviorRelay<Int>(value: 0)
     var isFocusRecordSaved: BehaviorRelay<Bool> = BehaviorRelay<Bool>(value: false)
@@ -86,7 +91,7 @@ final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusVi
             } onFailure: { [weak self] _ in
                 self?.isFocusRecordSaved.accept(false)
             }
-            .disposed(by: disposeBag)
+            .disposed(by: disposeBag) // runningStateDisposeBag
     }
     
     func changeMode() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
@@ -251,7 +251,7 @@ final class BreathFocusViewController: FocusViewController {
         let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
         let message = minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
         PushNotificationMananger.shared.presentFocusStopNotification(body: message)
-        FeedbacakGenerator.shared.impactOccurred()
+        FeedbackGenerator.shared.impactOccurred()
     }
     
     private func startBreath() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
@@ -200,6 +200,7 @@ final class BreathFocusViewController: FocusViewController {
                 self.stopBreath()
                 self.viewModel?.saveFocusRecord()
                 self.viewModel?.resetClockTimer()
+                FeedbacakGenerator.shared.impactOccurred()
             }
         }).disposed(by: disposeBag)
 

--- a/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
@@ -197,10 +197,10 @@ final class BreathFocusViewController: FocusViewController {
             case .running:
                 self.startBreath()
             case .stop:
+                self.alertNotification()
                 self.stopBreath()
                 self.viewModel?.saveFocusRecord()
                 self.viewModel?.resetClockTimer()
-                FeedbacakGenerator.shared.impactOccurred()
             }
         }).disposed(by: disposeBag)
 
@@ -240,6 +240,18 @@ final class BreathFocusViewController: FocusViewController {
             }
             
         }).disposed(by: disposeBag)
+    }
+    
+    private func alertNotification() {
+        guard let clockTime = self.viewModel?.clockTime.value else {
+            return
+        }
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
+        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
+        let message = minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
+        PushNotificationMananger.shared.presentFocusStopNotification(body: message)
+        FeedbacakGenerator.shared.impactOccurred()
     }
     
     private func startBreath() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
@@ -305,7 +305,7 @@ final class DefaultFocusViewController: FocusViewController {
         ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
         : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
         PushNotificationMananger.shared.presentFocusStopNotification(body: message)
-        FeedbacakGenerator.shared.impactOccurred()
+        FeedbackGenerator.shared.impactOccurred()
     }
     
     private func changeStateToReady() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
@@ -268,6 +268,8 @@ final class DefaultFocusViewController: FocusViewController {
                 guard let self = self else { return }
                 self.viewModel?.saveFocusRecord()
                 self.viewModel?.changeTimerState(to: .ready)
+                PushNotificationMananger.shared
+                    .presentFocusStopNotification(body: "완료시간 전에 종료되었습니다.")
                 self.viewModel?.resetClockTimer()
             }
             .disposed(by: disposeBag)

--- a/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
@@ -266,10 +266,9 @@ final class DefaultFocusViewController: FocusViewController {
         exitButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
+                self.alertNotification()
                 self.viewModel?.saveFocusRecord()
                 self.viewModel?.changeTimerState(to: .ready)
-                PushNotificationMananger.shared
-                    .presentFocusStopNotification(body: "완료시간 전에 종료되었습니다.")
                 self.viewModel?.resetClockTimer()
             }
             .disposed(by: disposeBag)
@@ -280,6 +279,7 @@ final class DefaultFocusViewController: FocusViewController {
                       let focusTime = self.viewModel?.focusTime
                 else { return }
                 if $0 == focusTime {
+                    self.alertNotification()
                     self.viewModel?.saveFocusRecord()
                     self.viewModel?.resetClockTimer()
                     self.changeStateToReady()
@@ -289,6 +289,23 @@ final class DefaultFocusViewController: FocusViewController {
                 self.startPulseAnimation(second: $0)
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func alertNotification() {
+        guard let focusTime = self.viewModel?.focusTime,
+              let clockTime = self.viewModel?.clockTime.value
+        else {
+            return
+        }
+        let sadEmojis = ["🥶", "😣", "😞", "😟", "😕"]
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
+        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
+        let message = focusTime - clockTime > 0
+        ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
+        : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
+        PushNotificationMananger.shared.presentFocusStopNotification(body: message)
+        FeedbacakGenerator.shared.impactOccurred()
     }
     
     private func changeStateToReady() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
@@ -241,6 +241,7 @@ final class InfinityFocusViewController: FocusViewController {
         exitButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
+                self.alertNotification()
                 self.viewModel?.changeTimerState(to: .ready)
                 self.viewModel?.resetClockTimer()
                 self.viewModel?.saveFocusRecord()
@@ -254,6 +255,18 @@ final class InfinityFocusViewController: FocusViewController {
                 self.startPulseAnimation(second: $0)
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func alertNotification() {
+        guard let clockTime = self.viewModel?.clockTime.value else {
+            return
+        }
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
+        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
+        let message = minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
+        PushNotificationMananger.shared.presentFocusStopNotification(body: message)
+        FeedbacakGenerator.shared.impactOccurred()
     }
     
     private func changeStateToReady() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
@@ -266,7 +266,7 @@ final class InfinityFocusViewController: FocusViewController {
         let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
         let message = minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
         PushNotificationMananger.shared.presentFocusStopNotification(body: message)
-        FeedbacakGenerator.shared.impactOccurred()
+        FeedbackGenerator.shared.impactOccurred()
     }
     
     private func changeStateToReady() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
@@ -310,7 +310,7 @@ final class PomodoroFocusViewController: FocusViewController {
         ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
         : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
         PushNotificationMananger.shared.presentFocusStopNotification(body: message)
-        FeedbacakGenerator.shared.impactOccurred()
+        FeedbackGenerator.shared.impactOccurred()
     }
     
     private func changeStateToReady() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
@@ -250,15 +250,14 @@ final class PomodoroFocusViewController: FocusViewController {
         exitButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
+                if self.viewModel?.mode.value == .work {
+                    self.alertNotification()
+                }
                 self.viewModel?.changeTimerState(to: .ready)
                 self.viewModel?.resetClockTimer()
                 self.viewModel?.saveFocusRecord()
                 self.viewModel?.resetTotalFocusTime()
                 self.viewModel?.changeToWorkMode()
-// MARK: Todo - Jogiking
-//                if viewModel?.mode.value == .work {
-//
-//                }
             }
             .disposed(by: disposeBag)
         
@@ -268,6 +267,7 @@ final class PomodoroFocusViewController: FocusViewController {
                       let focusTime = self.viewModel?.focusTime
                 else { return }
                 if $0 == focusTime {
+                    self.alertNotification()
                     self.viewModel?.changeMode()
                     self.viewModel?.resetClockTimer()
                     self.changeStateToReady()
@@ -294,6 +294,23 @@ final class PomodoroFocusViewController: FocusViewController {
                 }
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func alertNotification() {
+        guard let focusTime = self.viewModel?.focusTime,
+              let clockTime = self.viewModel?.clockTime.value
+        else {
+            return
+        }
+        let sadEmojis = ["🥶", "😣", "😞", "😟", "😕"]
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
+        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
+        let message = focusTime - clockTime > 0
+        ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
+        : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
+        PushNotificationMananger.shared.presentFocusStopNotification(body: message)
+        FeedbacakGenerator.shared.impactOccurred()
     }
     
     private func changeStateToReady() {

--- a/JipJung/JipJung/Utils/ApplicationLaunch.swift
+++ b/JipJung/JipJung/Utils/ApplicationLaunch.swift
@@ -11,10 +11,11 @@ import Foundation
 import Firebase
 import RealmSwift
 
-final class ApplicationLaunch {
+final class ApplicationLaunch: NSObject {
     func start() {
         configureFirebase()
         configureAudioSession()
+        configureLocalNotification()
         
         if isFirstLaunch() {
             do {
@@ -95,6 +96,30 @@ final class ApplicationLaunch {
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             print(error)
+        }
+    }
+    
+    func configureLocalNotification() {
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.requestAuthorization(options: [.alert,
+                                                          .sound]) {
+            (didAllow, error) in
+            print(#function, #line, didAllow, error)
+        }
+        UNUserNotificationCenter.current().delegate = self
+    }
+}
+
+extension ApplicationLaunch: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        completionHandler()
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        if #available(iOS 14.0, *) {
+            completionHandler(.banner)
+        } else {
+            completionHandler(.alert)
         }
     }
 }

--- a/JipJung/JipJung/Utils/FeedbackGenerator.swift
+++ b/JipJung/JipJung/Utils/FeedbackGenerator.swift
@@ -13,7 +13,7 @@ class FeedbacakGenerator {
     private var heavyGenerator: UIImpactFeedbackGenerator?
     
     private init() {
-        heavyGenerator = UIImpactFeedbackGenerator(style: .heavy)
+        heavyGenerator = UIImpactFeedbackGenerator(style: .light)
     }
     
     func impactOccurred() {

--- a/JipJung/JipJung/Utils/FeedbackGenerator.swift
+++ b/JipJung/JipJung/Utils/FeedbackGenerator.swift
@@ -1,0 +1,22 @@
+//
+//  FeedbackGenerator.swift
+//  JipJung
+//
+//  Created by turu on 2021/11/25.
+//
+
+import UIKit
+
+class FeedbacakGenerator {
+    static let shared = FeedbacakGenerator()
+    
+    private var heavyGenerator: UIImpactFeedbackGenerator?
+    
+    private init() {
+        heavyGenerator = UIImpactFeedbackGenerator(style: .heavy)
+    }
+    
+    func impactOccurred() {
+        heavyGenerator?.impactOccurred()
+    }
+}

--- a/JipJung/JipJung/Utils/FeedbackGenerator.swift
+++ b/JipJung/JipJung/Utils/FeedbackGenerator.swift
@@ -7,16 +7,16 @@
 
 import UIKit
 
-class FeedbacakGenerator {
-    static let shared = FeedbacakGenerator()
+class FeedbackGenerator {
+    static let shared = FeedbackGenerator()
     
-    private var heavyGenerator: UIImpactFeedbackGenerator?
+    private var lightGenerator: UIImpactFeedbackGenerator?
     
     private init() {
-        heavyGenerator = UIImpactFeedbackGenerator(style: .light)
+        lightGenerator = UIImpactFeedbackGenerator(style: .light)
     }
     
     func impactOccurred() {
-        heavyGenerator?.impactOccurred()
+        lightGenerator?.impactOccurred()
     }
 }

--- a/JipJung/JipJung/Utils/PushNotificationManager.swift
+++ b/JipJung/JipJung/Utils/PushNotificationManager.swift
@@ -1,0 +1,41 @@
+//
+//  PushNotificationManager.swift
+//  JipJung
+//
+//  Created by turu on 2021/11/25.
+//
+
+import Foundation
+import UserNotifications
+
+class PushNotificationMananger {
+    static let shared = PushNotificationMananger()
+    
+    private init() {}
+    
+    func presentFocusStopNotification(body: String) {
+        UNUserNotificationCenter.current().getNotificationSettings { status in
+            if status.authorizationStatus == UNAuthorizationStatus.authorized {
+                let content = UNMutableNotificationContent()
+                content.badge = 0
+                content.title = "집중 모드 종료"
+                content.body = body
+                content.sound = .default
+                
+                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.2,
+                                                                repeats: false)
+                let request = UNNotificationRequest(identifier: "stopFocus",
+                                                    content: content,
+                                                    trigger: trigger)
+                
+                UNUserNotificationCenter.current().add(request) { error in
+                    if let error = error {
+                        print(#function, #line, error)
+                    }
+                }
+            } else {
+                print("알림 권한이 없음")
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 작업 내용
- 각 화면별 집중모드를 종료할 때 푸시 알림이 울리게 했습니다.
- 배경화면에 있는 앱 아이콘에 뱃지가 생기지 않게 했습니다.
- 푸시 알림이 foreground에 있는 상태에서도 울리게 했습니다.
- 푸시 알림이 울리고나서 Notification center에 남지 않게 했습니다.
- 집중모드 종료 될 때 햅틱 피드백이 울리게 했습니다.
  - 햅틱 피드백은 다른 버튼들 터치할 때도 울리게 좋을 것 같습니다.
  - 햅틱 피드백 기능을 담당하는 매니저를 추가했습니다.
  - 현재 Exit 하는 버튼에만 붙였습니다.

# 관련된 이슈 번호
- close #153 

# 스크린 샷

https://user-images.githubusercontent.com/38206212/143435781-a684bf0a-bf4b-4917-a15d-9a9665f59c32.mov



