### PR TITLE
모드 별 음원 리스트 저장/삭제 기능

### DIFF
--- a/JipJung/JipJung/Data/Repositories/MediaListRepository.swift
+++ b/JipJung/JipJung/Data/Repositories/MediaListRepository.swift
@@ -23,4 +23,13 @@ final class MediaListRepository {
     func removeMediaFromMode(media: Media) -> Single<Bool> {
         return localDBManager.deleteMediaInMode(mediaID: media.id, mode: media.mode)
     }
+    
+    func removeMediaFromMode(id: String, mode: Int) -> Single<Bool> {
+        return localDBManager.deleteMediaInMode(mediaID: id, mode: mode)
+    }
+    
+    func saveMediaFromMode(id: String, mode: Int) -> Single<Bool> {
+        let data = mode == 0 ? BrightMedia(id: id) : DarknessMedia(id: id)
+        return localDBManager.write(data)
+    }
 }

--- a/JipJung/JipJung/Domain/UseCases/MediaListUseCase.swift
+++ b/JipJung/JipJung/Domain/UseCases/MediaListUseCase.swift
@@ -23,4 +23,12 @@ final class MediaListUseCase {
     func removeMediaFromMode(media: Media) -> Single<Bool> {
         return mediaListRepository.removeMediaFromMode(media: media)
     }
+    
+    func removeMediaFromMode(id: String, mode: Int) -> Single<Bool> {
+        mediaListRepository.removeMediaFromMode(id: id, mode: mode)
+    }
+    
+    func saveMediaFromMode(id: String, mode: Int) -> Single<Bool>  {
+        return mediaListRepository.saveMediaFromMode(id: id, mode: mode)
+    }
 }

--- a/JipJung/JipJung/UI/Sound/Views/MusicDescriptionView.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicDescriptionView.swift
@@ -25,12 +25,7 @@ class MusicDescriptionView: UIView {
         return label
     }()
     
-    var streamingButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.tintColor = UIColor(white: 1, alpha: 0.8)
-        button.setImage(UIImage(systemName: "headphones.circle"), for: .normal)
-        return button
-    }()
+    var plusButton: PlusCircleButton = PlusCircleButton()
     
     var tagView: UIView = {
         let view = UIView()
@@ -70,18 +65,18 @@ class MusicDescriptionView: UIView {
         
         contentView.addSubview(titleLabel)
         contentView.addSubview(explanationLabel)
-        contentView.addSubview(streamingButton)
+        contentView.addSubview(plusButton)
         contentView.addSubview(tagView)
         
-        streamingButton.snp.makeConstraints { make in
+        plusButton.snp.makeConstraints { make in
             make.top.trailing.equalToSuperview()
-            make.height.equalTo(titleLabel.snp.height)
+            make.size.equalTo(titleLabel.snp.height)
         }
         
         titleLabel.snp.makeConstraints { make in
             make.leading.top.equalToSuperview()
-            make.trailing.equalTo(streamingButton.snp.leading)
-            make.centerY.equalTo(streamingButton.snp.centerY)
+            make.trailing.equalTo(plusButton.snp.leading)
+            make.centerY.equalTo(plusButton.snp.centerY)
         }
 
         explanationLabel.snp.makeConstraints { make in

--- a/JipJung/JipJung/UI/Sound/Views/MusicPlayerButtons.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicPlayerButtons.swift
@@ -44,3 +44,13 @@ final class FavoriteCircleButton: MusicPlayerBaseButton {
         tintColor = .red
     }
 }
+
+final class PlusCircleButton: MusicPlayerBaseButton {
+    override func configure() {
+        super.configure()
+        self.backgroundColor = .clear
+        setImage(UIImage(systemName: "plus.circle.fill"), for: .normal)
+        setImage(UIImage(systemName: "checkmark.circle.fill"), for: .selected)
+        tintColor = .lightGray
+    }
+}

--- a/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
@@ -263,6 +263,19 @@ final class MusicPlayerViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
+        musicDescriptionView.plusButton.rx.tap
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                self.musicDescriptionView.plusButton.isSelected.toggle()
+                switch self.musicDescriptionView.plusButton.isSelected {
+                case false:
+                    self.viewModel?.removeMediaFromMode()
+                case true:
+                    self.viewModel?.saveMediaFromMode()
+                }
+            }
+            .disposed(by: disposeBag)
+        
         viewModel?.musicFileStatus
             .bind(onNext: { [weak self] in
                 guard let self = self else { return }
@@ -293,6 +306,13 @@ final class MusicPlayerViewController: UIViewController {
             .distinctUntilChanged()
             .bind(onNext: { [weak self] in
                 self?.favoriteButton.isSelected = $0
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel?.isInMusicList
+            .distinctUntilChanged()
+            .bind(onNext: { [weak self] in
+                self?.musicDescriptionView.plusButton.isSelected = $0
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
# 작업 내용
- 음원 상세 화면에서 Plus 버튼을 누르면 해당 음원을 리스트에 저장하고, 한 번 더 누르면 해당 음원을 리스트에서 삭제하는 기능을 구현

# 스크린 샷(optional)
![Simulator Screen Recording - iPhone 12 - 2021-11-25 at 21 46 38](https://user-images.githubusercontent.com/81892038/143444470-0535a0bb-6273-4461-93dc-eaed5c452d06.gif)
