### PR TITLE
Home: 음악 재생 관련 버그 수정

### DIFF
--- a/JipJung/JipJung/UI/Common/Extensions/Notification+Extension.swift
+++ b/JipJung/JipJung/UI/Common/Extensions/Notification+Extension.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let refreshHome = Notification.Name("RefreshHome")
+    static let showCarouselView = Notification.Name("ShowCarouselView")
 }

--- a/JipJung/JipJung/UI/Home/Focus/Views/FocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/FocusViewController.swift
@@ -31,7 +31,13 @@ class FocusViewController: UIViewController {
     
     private func bindCloseButton() {
         closeButton.rx.tap.bind { [weak self] _ in
-            self?.dismiss(animated: true)
+            self?.dismiss(animated: true) {
+                NotificationCenter.default.post(
+                    name: .showCarouselView,
+                    object: nil,
+                    userInfo: nil
+                )
+            }
         }
         .disposed(by: disposeBag)
     }

--- a/JipJung/JipJung/UI/Home/Main/Views/CarouselView.swift
+++ b/JipJung/JipJung/UI/Home/Main/Views/CarouselView.swift
@@ -258,8 +258,6 @@ class CarouselView: UIView {
                 self.previousView.pauseVideo()
                 self.currentView.pauseVideo()
                 self.nextView.pauseVideo()
-                
-                self.mediaPlayViewTapped()
             case .right:
                 let currentIndex = self.currentIndex.value
                 let contentsCount = self.contents.value.count
@@ -275,8 +273,6 @@ class CarouselView: UIView {
                 self.previousView.pauseVideo()
                 self.currentView.pauseVideo()
                 self.nextView.pauseVideo()
-                
-                self.mediaPlayViewTapped()
             case .none:
                 break
             }

--- a/JipJung/JipJung/UI/Home/Main/Views/CarouselView.swift
+++ b/JipJung/JipJung/UI/Home/Main/Views/CarouselView.swift
@@ -350,7 +350,7 @@ extension CarouselView {
             applyPaging(with: .none)
             mediaPlayViewTapped()
             return
-        } else if abs(distance.x) < 30 && abs(distance.y) > 100 {
+        } else if abs(distance.x) < 30 && distance.y > 100 {
             applyPaging(with: .none)
             mediaPlayViewDownSwiped()
         } else {

--- a/JipJung/JipJung/UI/Home/Main/Views/CarouselView.swift
+++ b/JipJung/JipJung/UI/Home/Main/Views/CarouselView.swift
@@ -14,7 +14,7 @@ import SnapKit
 protocol CarouselViewDelegate: AnyObject {
     func currentViewTapped()
     func currentViewDownSwiped(media: Media)
-    func currentViewAppear(audioFileName: String, autoPlay: Bool)
+    func currentViewAppear(media: Media, autoPlay: Bool)
 }
 
 class CarouselView: UIView {
@@ -312,7 +312,7 @@ class CarouselView: UIView {
             return
         }
 
-        delegate.currentViewAppear(audioFileName: media.audioFileName, autoPlay: autoPlay)
+        delegate.currentViewAppear(media: media, autoPlay: autoPlay)
     }
 }
 


### PR DESCRIPTION
# 작업 내용
- 좌우 스크롤 재생 기능 비활성화
- 삭제 제스쳐 아래쪽만 적용
- 화면 전환 시, 현재 음원 반영 부분 개선

# 관련된 이슈 번호
- close #163 
- close #178