### PR TITLE
음원상세화면 버그 해결

### DIFF
--- a/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
@@ -32,7 +32,6 @@ final class MusicPlayerViewController: UIViewController {
         let button = UIButton(type: .system)
         button.titleLabel?.font = .boldSystemFont(ofSize: 16)
         button.backgroundColor = .white
-        button.setTitle("Download To Play", for: .normal)
         button.layer.cornerRadius = 8
         return button
     }()
@@ -281,6 +280,7 @@ final class MusicPlayerViewController: UIViewController {
             .disposed(by: disposeBag)
         
         viewModel?.musicFileStatus
+            .distinctUntilChanged()
             .bind(onNext: { [weak self] state in
                 guard let self = self else { return }
                 DispatchQueue.main.async {

--- a/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
@@ -72,6 +72,10 @@ final class MusicPlayerViewController: UIViewController {
         viewModel?.checkMusicDownloaded()
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        viewModel?.pauseMusic()
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         playerLayer?.frame = topView.bounds

--- a/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicPlayerViewController.swift
@@ -72,6 +72,7 @@ final class MusicPlayerViewController: UIViewController {
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         viewModel?.pauseMusic()
     }
     


### PR DESCRIPTION
# 작업 내용
- 음원상세화면을 나가면 음원재생을 정지하도록 변경 #167 
- 음원다운로드 후 plus 버튼을 누르고 홈화면 이동하면 크래시 발생하는 문제 해결 #176

# 관련된 이슈 번호
close #167 
close #176