### PR TITLE
🐛 뽀모도로 화면에서 차오르는 게이지가 남은 시간에 맞게 수정, 타이머 최소 시간 단위 수정

### DIFF
--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
@@ -19,7 +19,7 @@ protocol PomodoroFocusViewModelInput {
     func startClockTimer()
     func pauseClockTimer()
     func resetClockTimer()
-    func setFocusTime(seconds: Int)
+    func setFocusTime(value: Int)
     func saveFocusRecord()
 }
 
@@ -35,8 +35,9 @@ final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusVi
     var timerState: BehaviorRelay<TimerState> = BehaviorRelay<TimerState>(value: .ready)
     var mode: BehaviorRelay<PomodoroMode> = BehaviorRelay<PomodoroMode>(value: .work)
     let focusTimeList: [Int] = [1, 5, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180]
-    var focusTime: Int = 60
+    lazy var focusTime: Int = timeUnit
     var totalFocusTime: Int = 0
+    let timeUnit = 5
     
     private var runningStateDisposeBag: DisposeBag = DisposeBag()
     private var disposeBag: DisposeBag = DisposeBag()
@@ -74,8 +75,8 @@ final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusVi
         runningStateDisposeBag = DisposeBag()
     }
     
-    func setFocusTime(seconds: Int) {
-        focusTime = seconds
+    func setFocusTime(value: Int) {
+        focusTime = value * timeUnit
     }
     
     func saveFocusRecord() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
@@ -23,7 +23,7 @@ final class PomodoroFocusViewController: FocusViewController {
     
     private lazy var minuteLabel: UILabel = {
         let minuteLabel = UILabel()
-        minuteLabel.text = "min"
+        minuteLabel.text = "sec"
         minuteLabel.textColor = .systemGray
         
         return minuteLabel
@@ -353,16 +353,22 @@ final class PomodoroFocusViewController: FocusViewController {
     }
     
     private func changeStateToRunning() {
+        // NOTE: 아직 다른 집중모드 코드에서는 이 옵셔널 바인딩하는 코드를 추가하지 않았음
+        guard let viewModel = viewModel else {
+            return
+        }
         startButton.isHidden = true
         timeLabel.isHidden = false
         timePickerView.isHidden = true
         minuteLabel.isHidden = true
-        viewModel?.startClockTimer()
-        switch viewModel?.timerState.value {
+        viewModel.startClockTimer()
+
+        switch viewModel.timerState.value {
         case .running(isResume: true):
             resumeTimerProgressAnimation()
         case .running(isResume: false):
-            startTimeProgressAnimation(with: viewModel?.focusTime ?? 0)
+            resumeTimerProgressAnimation()
+            startTimeProgressAnimation(with: viewModel.focusTime)
         default:
             break
         }
@@ -465,19 +471,24 @@ final class PomodoroFocusViewController: FocusViewController {
 
 extension PomodoroFocusViewController: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        let focusTime = (viewModel?.focusTimeList[row] ?? 0) * 60
-        viewModel?.setFocusTime(seconds: focusTime)
-        self.timeLabel.text = focusTime.digitalClockFormatted
+        let pickerValue = (viewModel?.focusTimeList[row] ?? 0)
+        viewModel?.setFocusTime(value: pickerValue)
+        self.timeLabel.text = pickerValue.digitalClockFormatted
     }
     
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        guard let minuteInfo = viewModel?.focusTimeList[row] else { return UILabel() }
+        // NOTE: 시연 용이성을 위해 변경
+        guard let viewModel = viewModel else {
+            return UILabel()
+        }
+        let pickerValue = viewModel.focusTimeList[row]
+        let text = "\(pickerValue * viewModel.timeUnit)"
         timePickerView.subviews.forEach {
             $0.backgroundColor = .clear
         }
         var pickerLabel: UILabel = UILabel()
         pickerLabel = UILabel()
-        pickerLabel.text = "\(minuteInfo)"
+        pickerLabel.text = "\(text)"
         pickerLabel.textColor = UIColor.white
         pickerLabel.font = UIFont.systemFont(ofSize: 35)
         pickerLabel.textAlignment = .center

--- a/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
@@ -362,7 +362,7 @@ final class PomodoroFocusViewController: FocusViewController {
         case .running(isResume: true):
             resumeTimerProgressAnimation()
         case .running(isResume: false):
-            startTimeProgressAnimation()
+            startTimeProgressAnimation(with: viewModel?.focusTime ?? 0)
         default:
             break
         }
@@ -434,11 +434,11 @@ final class PomodoroFocusViewController: FocusViewController {
         return circleShapeLayer
     }
     
-    private func startTimeProgressAnimation() {
+    private func startTimeProgressAnimation(with duration: Int) {
         let animation = CABasicAnimation(keyPath: #keyPath(CAShapeLayer.strokeEnd))
         animation.fromValue = 0
         animation.toValue = 1
-        animation.duration = 100
+        animation.duration = CFTimeInterval(duration)
         animation.fillMode = .forwards
         timeProgressLayer.add(animation, forKey: nil)
         view.layer.addSublayer(timeProgressLayer)


### PR DESCRIPTION
# 작업 내용
- 차오르는 게이지가 picker에서 설정한 시간에 맞게 올라가게 수정
- 시연을 위해 최소 시간단위를 1분에서 5초로 수정함

# 관련된 이슈 번호
close #173 
close #174 
