### PR TITLE
집중화면 모드 단말기 대응, 떠오르는 애니메이션 추가

### DIFF
--- a/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
@@ -27,7 +27,7 @@ final class BreathFocusViewController: FocusViewController {
         return minuteLabel
     }()
     
-    private lazy var timeLabel: UILabel = {
+    private lazy var numberOfBreathLabel: UILabel = {
         let timeLabel = UILabel()
         timeLabel.text = "7 breaths"
         timeLabel.font = UIFont.boldSystemFont(ofSize: 21)
@@ -138,9 +138,9 @@ final class BreathFocusViewController: FocusViewController {
         }
         countdownView.isHidden = true
         
-        view.addSubview(timeLabel)
-        timeLabel.snp.makeConstraints {
-            $0.top.equalTo(breathView.snp.bottom).offset(10)
+        view.addSubview(numberOfBreathLabel)
+        numberOfBreathLabel.snp.makeConstraints {
+            $0.top.equalTo(view.snp.centerY).multipliedBy(1.2)
             $0.centerX.equalToSuperview()
         }
         
@@ -260,7 +260,7 @@ final class BreathFocusViewController: FocusViewController {
     private func startBreath() {
         startButton.isHidden = true
         stopButton.isHidden = false
-        timeLabel.isHidden = true
+        numberOfBreathLabel.isHidden = true
         timePickerView.isHidden = true
         minuteLabel.isHidden = true
 
@@ -300,7 +300,7 @@ final class BreathFocusViewController: FocusViewController {
     private func stopBreath() {
         startButton.isHidden = false
         stopButton.isHidden = true
-        timeLabel.isHidden = false
+        numberOfBreathLabel.isHidden = false
         timePickerView.isHidden = false
         minuteLabel.isHidden = false
         breathShapeLayer.isHidden = false
@@ -368,7 +368,7 @@ extension BreathFocusViewController: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         let focusTime = (viewModel?.focusTimeList[row] ?? 0) * 7
         viewModel?.setFocusTime(seconds: focusTime)
-        self.timeLabel.text = "\(focusTime) breaths"
+        self.numberOfBreathLabel.text = "\(focusTime) breaths"
     }
     
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {

--- a/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
@@ -98,6 +98,29 @@ final class BreathFocusViewController: FocusViewController {
         bindUI()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        startButton.alpha = 0
+        breathView.alpha = 0
+        let viewCenter = view.center
+        breathView.center = CGPoint(x: viewCenter.x, y: viewCenter.y * 0.9)
+        UIView.animate(withDuration: 0.6, delay: 0.3, options: []) { [weak self] in
+            self?.breathView.alpha = 1
+            self?.breathView.center = CGPoint(x: viewCenter.x, y: viewCenter.y * 0.8)
+            self?.startButton.alpha = 1
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        let viewCenter = view.center
+        UIView.animate(withDuration: 0.6) { [weak self] in
+            self?.breathView.center = viewCenter
+            self?.startButton.alpha = 0
+        }
+    }
+    
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         breathShapeLayer.frame = breathView.bounds
@@ -109,7 +132,7 @@ final class BreathFocusViewController: FocusViewController {
     }
     
     // MARK: - Initializer
-
+    
     convenience init(viewModel: BreathFocusViewModel) {
         self.init(nibName: nil, bundle: nil)
         self.viewModel = viewModel
@@ -144,12 +167,12 @@ final class BreathFocusViewController: FocusViewController {
             $0.centerX.equalToSuperview()
         }
         
-        view.addSubview(timePickerView)
+        breathView.addSubview(timePickerView)
         timePickerView.snp.makeConstraints {
             $0.center.equalTo(breathView.snp.center)
         }
         
-        view.addSubview(minuteLabel)
+        breathView.addSubview(minuteLabel)
         minuteLabel.snp.makeConstraints {
             $0.centerY.equalTo(timePickerView)
             $0.centerX.equalTo(timePickerView.snp.centerX).offset(60)
@@ -192,18 +215,18 @@ final class BreathFocusViewController: FocusViewController {
             .skip(1)
             .distinctUntilChanged()
             .bind(onNext: { [weak self] in
-            guard let self = self else { return }
-            switch $0 {
-            case .running:
-                self.startBreath()
-            case .stop:
-                self.alertNotification()
-                self.stopBreath()
-                self.viewModel?.saveFocusRecord()
-                self.viewModel?.resetClockTimer()
-            }
-        }).disposed(by: disposeBag)
-
+                guard let self = self else { return }
+                switch $0 {
+                case .running:
+                    self.startBreath()
+                case .stop:
+                    self.alertNotification()
+                    self.stopBreath()
+                    self.viewModel?.saveFocusRecord()
+                    self.viewModel?.resetClockTimer()
+                }
+            }).disposed(by: disposeBag)
+        
         viewModel?.clockTime.bind(onNext: { [weak self] in
             guard let self = self else { return }
             if $0 % 7 == 3 {
@@ -226,7 +249,10 @@ final class BreathFocusViewController: FocusViewController {
                                delay: 0.0,
                                options: .allowUserInteraction,
                                animations: {
-                    self.view.layer.backgroundColor = .init(red: 129.0 / 255.0, green: 240.0 / 255.0, blue: 135.0 / 255.0, alpha: 0.8)
+                    self.view.layer.backgroundColor = .init(red: 129.0 / 255.0,
+                                                            green: 240.0 / 255.0,
+                                                            blue: 135.0 / 255.0,
+                                                            alpha: 0.8)
                 },
                                completion: nil)
             } else if $0 % 7 == 4 {
@@ -234,7 +260,10 @@ final class BreathFocusViewController: FocusViewController {
                                delay: 0.0,
                                options: .allowUserInteraction,
                                animations: {
-                    self.view.layer.backgroundColor = .init(red: 131.0 / 255.0, green: 79.0 / 255.0, blue: 163.0 / 255.0, alpha: 0.3)
+                    self.view.layer.backgroundColor = .init(red: 131.0 / 255.0,
+                                                            green: 79.0 / 255.0,
+                                                            blue: 163.0 / 255.0,
+                                                            alpha: 0.3)
                 },
                                completion: nil)
             }
@@ -263,9 +292,9 @@ final class BreathFocusViewController: FocusViewController {
         numberOfBreathLabel.isHidden = true
         timePickerView.isHidden = true
         minuteLabel.isHidden = true
-
+        
         startIntroAnimation()
-
+        
         // 진입 배경 애니메이션 연결 처리
         self.stopButton.layer.opacity = 0
         UIView.animate(withDuration: 0.4, delay: .zero, options: .curveEaseIn) {
@@ -276,10 +305,10 @@ final class BreathFocusViewController: FocusViewController {
             UIView.animate(withDuration: 3) {
                 self.view.layer.backgroundColor = .none
             }
-
+            
             // TODO: 버튼 동시 클릭 문제 해결, 버튼 나타나는 타이밍 조정하기
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                UIView.animate(withDuration: 2.0) {
+                UIView.animate(withDuration: 2.0, delay: .zero, options: .allowUserInteraction) {
                     self.stopButton.layer.opacity = 1
                 }
             }
@@ -316,11 +345,11 @@ final class BreathFocusViewController: FocusViewController {
         let scaleUpAnimation = CABasicAnimation(keyPath: "transform.scale")
         scaleUpAnimation.fromValue = 1.0
         scaleUpAnimation.toValue = 5.0
-
+        
         let opacityDownAnimation = CABasicAnimation(keyPath: "opacity")
         opacityDownAnimation.fromValue = 1.0
         opacityDownAnimation.toValue = 0.5
-
+        
         let introAnimations = CAAnimationGroup()
         introAnimations.animations = [scaleUpAnimation, opacityDownAnimation]
         introAnimations.repeatCount = 1
@@ -401,15 +430,7 @@ extension BreathFocusViewController: UIPickerViewDataSource {
     }
 }
 extension BreathFocusViewController: CAAnimationDelegate {
-    func animationDidStart(_ anim: CAAnimation) {
-        // MARK: 디버깅 할 때 필요해서 남겨 두었습니다
-        print(#function, #line)
-    }
-
     func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
-        // MARK: 디버깅 할 때 필요해서 남겨 두었습니다
-        print(#function, #line, flag, anim.description)
-
         viewModel?.changeState(to: .stop)
     }
 }

--- a/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
@@ -12,8 +12,10 @@ import RxRelay
 
 final class DefaultFocusViewController: FocusViewController {
     // MARK: - Subviews
-    private lazy var timerView: UIView = {
-        let timerView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 300, height: 300)))
+    let timerView: UIView = {
+        let length = UIScreen.deviceScreenSize.width * 0.7
+        let size = CGSize(width: length, height: length)
+        let timerView = UIView(frame: CGRect(origin: .zero, size: size))
         return timerView
     }()
     
@@ -126,8 +128,8 @@ final class DefaultFocusViewController: FocusViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
         configureTimerUI()
+        configureUI()
         bindUI()
     }
     
@@ -405,10 +407,13 @@ final class DefaultFocusViewController: FocusViewController {
         }
     }
     
-    private func createCircleShapeLayer(strokeColor: UIColor, lineWidth: CGFloat, startAngle: CGFloat = 0, endAngle: CGFloat = 2 * CGFloat.pi) -> CAShapeLayer {
+    private func createCircleShapeLayer(strokeColor: UIColor,
+                                        lineWidth: CGFloat,
+                                        startAngle: CGFloat = 0,
+                                        endAngle: CGFloat = 2 * CGFloat.pi) -> CAShapeLayer {
         let circleShapeLayer = CAShapeLayer()
         let circlePath = UIBezierPath(arcCenter: .zero,
-                                      radius: 125,
+                                      radius: timerView.bounds.width * 0.8 * 0.5,
                                       startAngle: startAngle,
                                       endAngle: endAngle,
                                       clockwise: true)
@@ -425,8 +430,6 @@ final class DefaultFocusViewController: FocusViewController {
         let animation = CABasicAnimation(keyPath: #keyPath(CAShapeLayer.strokeEnd))
         animation.fromValue = 0
         animation.toValue = 1
-        print(duration)
-        print(CFTimeInterval(duration))
         animation.duration = CFTimeInterval(duration)
         animation.fillMode = .backwards
         timeProgressLayer.add(animation, forKey: nil)

--- a/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
@@ -12,9 +12,10 @@ import RxRelay
 
 final class InfinityFocusViewController: FocusViewController {
     // MARK: - Subviews
-    private lazy var timerView: UIView = {
-        let timerView = UIView(frame: UIScreen.main.bounds)
-        timerView.isUserInteractionEnabled = false
+    let timerView: UIView = {
+        let length = UIScreen.deviceScreenSize.width * 0.7
+        let size = CGSize(width: length, height: length)
+        let timerView = UIView(frame: CGRect(origin: .zero, size: size))
         return timerView
     }()
     
@@ -345,10 +346,13 @@ final class InfinityFocusViewController: FocusViewController {
         }
     }
     
-    private func createCircleShapeLayer(strokeColor: UIColor, lineWidth: CGFloat, startAngle: CGFloat = 0, endAngle: CGFloat = 2 * CGFloat.pi) -> CAShapeLayer {
+    private func createCircleShapeLayer(strokeColor: UIColor,
+                                        lineWidth: CGFloat,
+                                        startAngle: CGFloat = 0,
+                                        endAngle: CGFloat = 2 * CGFloat.pi) -> CAShapeLayer {
         let circleShapeLayer = CAShapeLayer()
         let circlePath = UIBezierPath(arcCenter: .zero,
-                                      radius: 125,
+                                      radius: timerView.bounds.width * 0.8 * 0.5,
                                       startAngle: startAngle,
                                       endAngle: endAngle,
                                       clockwise: true)
@@ -372,7 +376,7 @@ final class InfinityFocusViewController: FocusViewController {
     private func createCometCircleShapeLayer(strokeColor: UIColor, lineWidth: CGFloat) -> CALayer {
         let circleShapeLayer = CAShapeLayer()
         let circlePath = UIBezierPath(arcCenter: .zero,
-                                      radius: 125,
+                                      radius: timerView.bounds.width * 0.8 * 0.5,
                                       startAngle: 0,
                                       endAngle: 2 * CGFloat.pi,
                                       clockwise: true)
@@ -382,11 +386,11 @@ final class InfinityFocusViewController: FocusViewController {
         circleShapeLayer.lineCap = CAShapeLayerLineCap.round
         circleShapeLayer.lineWidth = lineWidth
         circleShapeLayer.fillColor = UIColor.clear.cgColor
-        circleShapeLayer.position = view.center
+        circleShapeLayer.position = timerView.center
         
         let gradient = CAGradientLayer()
         gradient.frame = timerView.bounds
-        gradient.position = view.center
+        gradient.position = timerView.center
         gradient.colors = [UIColor.systemGray.cgColor, strokeColor.cgColor]
         gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
         gradient.endPoint = CGPoint(x: 1.0, y: 1)


### PR DESCRIPTION
# 작업 내용
- 기본, 무한, 뽀모도로 -> 단말기 화면에 적절하게 보이게 레이아웃 수정(아이폰8, 아이폰12, 아이폰12 pro max)
- 뽀모도로, 심호흡 -> 떠오르는 애니메이션 추가
- 심호흡의 원형크기와 버튼 레이아웃 위치들은 다른 집중모드들과 다르게 배치함
  - 현재 크기보다 작아지면 비정형 애니메이션이 이상해짐
- 다크모드일 때 뽀모도로의 원형이 어둡게 보이는 문제 수정
- 뽀모도로의 ViewController 코드를 기본, 무한의 ViewController쪽으로 통일함
  - breath는 다른 집중화면들과 layout 설정 순서에 대해서 차이가 있어서 그대로둠
  - 코드 통일할때 큰 코드 변경이 없는 방향으로 진행했음
- 버그수정
  - #171 
- 코드작업중 해결 확인된 버그 
  -  #175 
  -  #179 
  -  #180

# 관련된 이슈 번호
close #171 
close #175 
close #179 
close #180 

# 스크린샷

https://user-images.githubusercontent.com/38206212/143907147-558557fb-0d9b-4467-ac57-2f3a225a0ffb.mov


