### PR TITLE
focus 화면들 리팩토링

### DIFF
--- a/JipJung/JipJung.xcodeproj/project.pbxproj
+++ b/JipJung/JipJung.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		DF30FF05273CBC3B001C720E /* MusicPlayerButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF30FF04273CBC3B001C720E /* MusicPlayerButtons.swift */; };
 		DF6B111127390F1900D9924E /* MediaResourceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6B111027390F1900D9924E /* MediaResourceRepository.swift */; };
 		DF71D22F2734455600CD980E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DF71D22E2734455600CD980E /* GoogleService-Info.plist */; };
+		DFA33D51275617D700E675BF /* FocusButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA33D50275617D700E675BF /* FocusButtons.swift */; };
 		DFED21CB2733702800E99641 /* MusicPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFED21CA2733702800E99641 /* MusicPlayerViewController.swift */; };
 		DFED21D02733931600E99641 /* MusicDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFED21CF2733931600E99641 /* MusicDescriptionView.swift */; };
 		DFED21D92733AE8400E99641 /* MusicPlayerMaximView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFED21D82733AE8400E99641 /* MusicPlayerMaximView.swift */; };
@@ -432,6 +433,7 @@
 		DF30FF04273CBC3B001C720E /* MusicPlayerButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPlayerButtons.swift; sourceTree = "<group>"; };
 		DF6B111027390F1900D9924E /* MediaResourceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaResourceRepository.swift; sourceTree = "<group>"; };
 		DF71D22E2734455600CD980E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		DFA33D50275617D700E675BF /* FocusButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusButtons.swift; sourceTree = "<group>"; };
 		DFED21CA2733702800E99641 /* MusicPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPlayerViewController.swift; sourceTree = "<group>"; };
 		DFED21CF2733931600E99641 /* MusicDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicDescriptionView.swift; sourceTree = "<group>"; };
 		DFED21D82733AE8400E99641 /* MusicPlayerMaximView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPlayerMaximView.swift; sourceTree = "<group>"; };
@@ -645,6 +647,7 @@
 				DD828094273D1F8E00BB2A60 /* FocusViewController.swift */,
 				B40D1FA8273B5F1900881A49 /* DefaultFocusViewController.swift */,
 				B40D1FAC273B5F2700881A49 /* PomodoroFocusViewController.swift */,
+				DFA33D50275617D700E675BF /* FocusButtons.swift */,
 				B40D1FB8273B674F00881A49 /* InfinityFocusViewController.swift */,
 				B4B780DE2741F6FA0080DC28 /* BreathFocusViewController.swift */,
 				DD82808B273CAE5F00BB2A60 /* FocusViewControllerFactory.swift */,
@@ -1434,6 +1437,7 @@
 				DF6B111127390F1900D9924E /* MediaResourceRepository.swift in Sources */,
 				B481FC7F2745238100D1F2EA /* FavoriteRepository.swift in Sources */,
 				DDB5CEB82733765500E8F9EB /* FavoriteMaxim.swift in Sources */,
+				DFA33D51275617D700E675BF /* FocusButtons.swift in Sources */,
 				DD82808C273CAE5F00BB2A60 /* FocusViewControllerFactory.swift in Sources */,
 				B4B780E12741F7070080DC28 /* BreathFocusViewModel.swift in Sources */,
 				DDB5CEA227328EC300E8F9EB /* ExploreViewController.swift in Sources */,

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/BreathFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/BreathFocusViewModel.swift
@@ -16,6 +16,7 @@ protocol BreathFocusViewModelInput {
     func resetClockTimer()
     func setFocusTime(seconds: Int)
     func saveFocusRecord()
+    func alertNotification()
 }
 
 enum BreathFocusState {

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/BreathFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/BreathFocusViewModel.swift
@@ -99,10 +99,12 @@ final class BreathFocusViewModel: BreathFocusViewModelInput, BreathFocusViewMode
         let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
         let times = clockTime / 7
         let message = times > 0
-        ? "\(clockTime / 7)회 호흡 운동하셨습니다." + (happyEmojis.randomElement() ?? "")
+        ? "\(times)회 호흡 운동하셨습니다." + (happyEmojis.randomElement() ?? "")
         : "\(times)회... 반복했습니다. 집중합시다!" + (angryEmpjis.randomElement() ?? "")
-        PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
-                                                                     body: message)
+        PushNotificationMananger.shared.presentFocusStopNotification(
+            title: .focusFinish,
+            body: message
+        )
         FeedbackGenerator.shared.impactOccurred()
     }
 }

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/BreathFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/BreathFocusViewModel.swift
@@ -91,4 +91,17 @@ final class BreathFocusViewModel: BreathFocusViewModelInput, BreathFocusViewMode
             }
             .disposed(by: disposeBag)
     }
+    
+    func alertNotification() {
+        let clockTime = clockTime.value
+        let angryEmpjis = ["😡", "🤬", "🥵", "🥶", "😰"]
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let times = clockTime / 7
+        let message = times > 0
+        ? "\(clockTime / 7)회 호흡 운동하셨습니다." + (happyEmojis.randomElement() ?? "")
+        : "\(times)회... 반복했습니다. 집중합시다!" + (angryEmpjis.randomElement() ?? "")
+        PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
+                                                                     body: message)
+        FeedbackGenerator.shared.impactOccurred()
+    }
 }

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/DefaultFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/DefaultFocusViewModel.swift
@@ -16,6 +16,7 @@ protocol DefaultFocusViewModelInput {
     func resetClockTimer()
     func setFocusTime(seconds: Int)
     func saveFocusRecord()
+    func alertNotification()
 }
 
 protocol DefaultFocusViewModelOutput {
@@ -78,5 +79,22 @@ final class DefaultFocusViewModel: DefaultFocusViewModelInput, DefaultFocusViewM
                 self?.isFocusRecordSaved.accept(false)
             }
             .disposed(by: disposeBag)
+    }
+    
+    func alertNotification() {
+        let clockTime = clockTime.value
+        let sadEmojis = ["🥶", "😣", "😞", "😟", "😕"]
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
+        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
+        let message = focusTime - clockTime > 0
+        ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
+        : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
+        PushNotificationMananger.shared.presentFocusStopNotification(
+            title: .focusFinish,
+            body: message
+        )
+        
+        FeedbackGenerator.shared.impactOccurred()
     }
 }

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/InfinityFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/InfinityFocusViewModel.swift
@@ -15,6 +15,7 @@ protocol InfinityFocusViewModelInput {
     func pauseClockTimer()
     func resetClockTimer()
     func saveFocusRecord()
+    func alertNotification()
 }
 
 protocol InfinityFocusViewModelOutput {

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/InfinityFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/InfinityFocusViewModel.swift
@@ -72,4 +72,15 @@ final class InfinityFocusViewModel: InfinityFocusViewModelInput, InfinityFocusVi
             }
             .disposed(by: disposeBag)
     }
+    
+    func alertNotification() {
+        let clockTime = clockTime.value
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
+        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
+        let message = minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
+        PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
+                                                                     body: message)
+        FeedbackGenerator.shared.impactOccurred()
+    }
 }

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/InfinityFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/InfinityFocusViewModel.swift
@@ -80,8 +80,10 @@ final class InfinityFocusViewModel: InfinityFocusViewModelInput, InfinityFocusVi
         let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
         let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
         let message = minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
-        PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
-                                                                     body: message)
+        PushNotificationMananger.shared.presentFocusStopNotification(
+            title: .focusFinish,
+            body: message
+        )
         FeedbackGenerator.shared.impactOccurred()
     }
 }

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
@@ -106,4 +106,26 @@ final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusVi
     func resetTotalFocusTime() {
         totalFocusTime = 0
     }
+    
+    func alertNotification() {
+        let clockTime = clockTime.value
+        let sadEmojis = ["🥶", "😣", "😞", "😟", "😕"]
+        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
+        let relaxEmojis = ["👍", "👏", "🤜", "🙌", "🙏"]
+        switch mode.value {
+        case .work:
+            let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
+            let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
+            let message = focusTime - clockTime > 0
+            ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
+            : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
+            PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
+                                                                         body: message)
+        case .relax:
+            let message = "휴식시간이 끝났어요! 다시 집중해볼까요?" + (relaxEmojis.randomElement() ?? "")
+            PushNotificationMananger.shared.presentFocusStopNotification(title: .relaxFinish,
+                                                                         body: message)
+        }
+        FeedbackGenerator.shared.impactOccurred()
+    }
 }

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
@@ -21,6 +21,7 @@ protocol PomodoroFocusViewModelInput {
     func resetClockTimer()
     func setFocusTime(value: Int)
     func saveFocusRecord()
+    func alertNotification()
 }
 
 protocol PomodoroFocusViewModelOutput {

--- a/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
+++ b/JipJung/JipJung/UI/Home/Focus/ViewModels/PomodoroFocusViewModel.swift
@@ -120,12 +120,16 @@ final class PomodoroFocusViewModel: PomodoroFocusViewModelInput, PomodoroFocusVi
             let message = focusTime - clockTime > 0
             ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
             : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
-            PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
-                                                                         body: message)
+            PushNotificationMananger.shared.presentFocusStopNotification(
+                title: .focusFinish,
+                body: message
+            )
         case .relax:
             let message = "휴식시간이 끝났어요! 다시 집중해볼까요?" + (relaxEmojis.randomElement() ?? "")
-            PushNotificationMananger.shared.presentFocusStopNotification(title: .relaxFinish,
-                                                                         body: message)
+            PushNotificationMananger.shared.presentFocusStopNotification(
+                title: .relaxFinish,
+                body: message
+            )
         }
         FeedbackGenerator.shared.impactOccurred()
     }

--- a/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
@@ -200,7 +200,7 @@ final class BreathFocusViewController: FocusViewController {
                 case .running:
                     self.startBreath()
                 case .stop:
-                    self.alertNotification()
+                    self.viewModel?.alertNotification()
                     self.stopBreath()
                     self.viewModel?.saveFocusRecord()
                     self.viewModel?.resetClockTimer()
@@ -225,45 +225,38 @@ final class BreathFocusViewController: FocusViewController {
                 self.textLayer.string = "Inhale"
                 self.textLayer.opacity = 1
                 
-                UIView.animate(withDuration: 4.0,
-                               delay: 0.0,
-                               options: .allowUserInteraction,
-                               animations: {
-                    self.view.layer.backgroundColor = .init(red: 129.0 / 255.0,
-                                                            green: 240.0 / 255.0,
-                                                            blue: 135.0 / 255.0,
-                                                            alpha: 0.8)
-                },
-                               completion: nil)
+                UIView.animate(
+                    withDuration: 4.0,
+                    delay: 0.0,
+                    options: .allowUserInteraction,
+                    animations: {
+                        self.view.layer.backgroundColor = .init(
+                            red: 129.0 / 255.0,
+                            green: 240.0 / 255.0,
+                            blue: 135.0 / 255.0,
+                            alpha: 0.8
+                        )
+                    },
+                    completion: nil
+                )
             } else if $0 % 7 == 4 {
-                UIView.animate(withDuration: 3.0,
-                               delay: 0.0,
-                               options: .allowUserInteraction,
-                               animations: {
-                    self.view.layer.backgroundColor = .init(red: 131.0 / 255.0,
-                                                            green: 79.0 / 255.0,
-                                                            blue: 163.0 / 255.0,
-                                                            alpha: 0.3)
+                UIView.animate(
+                    withDuration: 3.0,
+                    delay: 0.0,
+                    options: .allowUserInteraction,
+                    animations: {
+                    self.view.layer.backgroundColor = .init(
+                        red: 131.0 / 255.0,
+                        green: 79.0 / 255.0,
+                        blue: 163.0 / 255.0,
+                        alpha: 0.3
+                    )
                 },
-                               completion: nil)
+                    completion: nil
+                )
             }
             
         }).disposed(by: disposeBag)
-    }
-    
-    private func alertNotification() {
-        guard let clockTime = self.viewModel?.clockTime.value else {
-            return
-        }
-        let angryEmpjis = ["😡", "🤬", "🥵", "🥶", "😰"]
-        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
-        let times = clockTime / 7
-        let message = times > 0
-        ? "\(clockTime / 7)회 호흡 운동하셨습니다." + (happyEmojis.randomElement() ?? "")
-        : "\(times)회... 반복했습니다. 집중합시다!" + (angryEmpjis.randomElement() ?? "")
-        PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
-                                                                     body: message)
-        FeedbackGenerator.shared.impactOccurred()
     }
     
     private func startBreath() {

--- a/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/BreathFocusViewController.swift
@@ -60,30 +60,10 @@ final class BreathFocusViewController: FocusViewController {
     }()
     private let countdownView = CountdownView()
     
-    private lazy var startButton: UIButton = {
-        let startButton = UIButton()
-        startButton.tintColor = .gray
-        let playImage = UIImage(systemName: "play.fill")?.withRenderingMode(.alwaysTemplate)
-        startButton.setImage(playImage, for: .normal)
-        startButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 12)
-        startButton.setTitle("Start", for: .normal)
-        startButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        startButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
-        startButton.setTitleColor(UIColor.gray, for: .normal)
-        startButton.layer.cornerRadius = 25
-        startButton.backgroundColor = .white
-        return startButton
-    }()
-    
-    private lazy var stopButton: UIButton = {
-        let stopButton = UIButton()
+    private let startButton = FocusStartButton()
+    private let stopButton: FocusExitButton = {
+        let stopButton = FocusExitButton()
         stopButton.setTitle("Stop", for: .normal)
-        stopButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        stopButton.setTitleColor(UIColor.white, for: .normal)
-        stopButton.layer.cornerRadius = 25
-        stopButton.backgroundColor = .lightGray
-        stopButton.layer.borderColor = UIColor.white.cgColor
-        stopButton.layer.borderWidth = 2
         return stopButton
     }()
     

--- a/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
@@ -64,55 +64,10 @@ final class DefaultFocusViewController: FocusViewController {
     
     private let pulseGroupLayer = CALayer()
     
-    private lazy var startButton: UIButton = {
-        let startButton = UIButton()
-        startButton.tintColor = .gray
-        let playImage = UIImage(systemName: "play.fill")?.withRenderingMode(.alwaysTemplate)
-        startButton.setImage(playImage, for: .normal)
-        startButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 12)
-        startButton.setTitle("Start", for: .normal)
-        startButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        startButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
-        startButton.setTitleColor(UIColor.gray, for: .normal)
-        startButton.layer.cornerRadius = 25
-        startButton.backgroundColor = .white
-        return startButton
-    }()
-    
-    private lazy var pauseButton: UIButton = {
-        let pauseButton = UIButton()
-        pauseButton.setTitle("Pause", for: .normal)
-        pauseButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
-        pauseButton.setTitleColor(UIColor.white, for: .normal)
-        pauseButton.layer.cornerRadius = 25
-        pauseButton.backgroundColor = .gray
-        pauseButton.layer.borderColor = UIColor.white.cgColor
-        pauseButton.layer.borderWidth = 2
-        return pauseButton
-    }()
-    
-    private lazy var continueButton: UIButton = {
-        let continueButton = UIButton()
-        continueButton.tintColor = .gray
-        continueButton.setTitle("Continue", for: .normal)
-        continueButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        continueButton.setTitleColor(UIColor.gray, for: .normal)
-        continueButton.layer.cornerRadius = 25
-        continueButton.backgroundColor = .white
-        return continueButton
-    }()
-    
-    private lazy var exitButton: UIButton = {
-        let exitButton = UIButton()
-        exitButton.setTitle("Exit", for: .normal)
-        exitButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
-        exitButton.setTitleColor(UIColor.white, for: .normal)
-        exitButton.layer.cornerRadius = 25
-        exitButton.backgroundColor = .gray
-        exitButton.layer.borderColor = UIColor.white.cgColor
-        exitButton.layer.borderWidth = 2
-        return exitButton
-    }()
+    private let startButton = FocusStartButton()
+    private let pauseButton = FocusPauseButton()
+    private let continueButton = FocusContinueButton()
+    private let exitButton = FocusExitButton()
     
     // MARK: - Private Variables
     

--- a/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/DefaultFocusViewController.swift
@@ -73,7 +73,7 @@ final class DefaultFocusViewController: FocusViewController {
     
     private var viewModel: DefaultFocusViewModel?
     // MARK: - Initializer
-
+    
     convenience init(viewModel: DefaultFocusViewModel) {
         self.init(nibName: nil, bundle: nil)
         self.viewModel = viewModel
@@ -151,7 +151,7 @@ final class DefaultFocusViewController: FocusViewController {
             $0.width.equalTo(FocusViewButtonSize.startButton.width)
             $0.height.equalTo(FocusViewButtonSize.startButton.height)
         }
-
+        
         view.addSubview(pauseButton)
         pauseButton.snp.makeConstraints {
             $0.top.equalTo(view.snp.centerY).multipliedBy(1.4)
@@ -159,7 +159,7 @@ final class DefaultFocusViewController: FocusViewController {
             $0.width.equalTo(FocusViewButtonSize.pauseButton.width)
             $0.height.equalTo(FocusViewButtonSize.pauseButton.height)
         }
-
+        
         view.addSubview(continueButton)
         continueButton.snp.makeConstraints {
             $0.top.equalTo(view.snp.centerY).multipliedBy(1.4)
@@ -167,7 +167,7 @@ final class DefaultFocusViewController: FocusViewController {
             $0.width.equalTo(FocusViewButtonSize.continueButton.width)
             $0.height.equalTo(FocusViewButtonSize.continueButton.height)
         }
-
+        
         view.addSubview(exitButton)
         exitButton.snp.makeConstraints {
             $0.top.equalTo(view.snp.centerY).multipliedBy(1.4)
@@ -179,20 +179,27 @@ final class DefaultFocusViewController: FocusViewController {
     
     private func bindUI() {
         viewModel?.timerState.bind(onNext: { [weak self] in
-                guard let self = self else { return }
-                switch $0 {
-                case .ready:
-                    self.changeStateToReady()
-                case .running(let isResume):
-                    if isResume {
-                        self.changeStateToResume()
-                    } else {
-                        self.changeStateToStart(with: self.viewModel?.focusTime ?? 0)
-                    }
-                case .paused:
-                    self.changeStateToPaused()
+            guard let self = self,
+                  let viewModel = self.viewModel
+            else {
+                return
+            }
+            
+            switch $0 {
+            case .ready:
+                self.presentReady(value: viewModel.focusTime)
+            case .running(let isResume):
+                if isResume {
+                    self.presentResume()
+                } else {
+                    viewModel.startClockTimer()
+                    self.presentStart(with: viewModel.focusTime)
                 }
-            })
+            case .paused:
+                viewModel.pauseClockTimer()
+                self.presentPaused()
+            }
+        })
             .disposed(by: disposeBag)
         
         startButton.rx.tap
@@ -219,7 +226,7 @@ final class DefaultFocusViewController: FocusViewController {
         exitButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
-                self.alertNotification()
+                self.viewModel?.alertNotification()
                 self.viewModel?.saveFocusRecord()
                 self.viewModel?.changeTimerState(to: .ready)
                 self.viewModel?.resetClockTimer()
@@ -232,10 +239,10 @@ final class DefaultFocusViewController: FocusViewController {
                       let focusTime = self.viewModel?.focusTime
                 else { return }
                 if $0 == focusTime {
-                    self.alertNotification()
+                    self.viewModel?.alertNotification()
                     self.viewModel?.saveFocusRecord()
                     self.viewModel?.resetClockTimer()
-                    self.changeStateToReady()
+                    self.presentReady(value: focusTime)
                     return
                 }
                 self.timeLabel.text = (focusTime - $0).digitalClockFormatted
@@ -244,26 +251,8 @@ final class DefaultFocusViewController: FocusViewController {
             .disposed(by: disposeBag)
     }
     
-    private func alertNotification() {
-        guard let focusTime = self.viewModel?.focusTime,
-              let clockTime = self.viewModel?.clockTime.value
-        else {
-            return
-        }
-        let sadEmojis = ["🥶", "😣", "😞", "😟", "😕"]
-        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
-        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
-        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
-        let message = focusTime - clockTime > 0
-        ? "완료시간 전에 종료되었어요." + (sadEmojis.randomElement() ?? "")
-        : minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
-        PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
-                                                                     body: message)
-        FeedbackGenerator.shared.impactOccurred()
-    }
-    
-    private func changeStateToReady() {
-        timeLabel.text = viewModel?.focusTime.digitalClockFormatted
+    private func presentReady(value: Int) {
+        timeLabel.text = value.digitalClockFormatted
         pauseButton.isHidden = true
         timeLabel.isHidden = true
         timePickerView.isHidden = false
@@ -291,23 +280,22 @@ final class DefaultFocusViewController: FocusViewController {
         }
     }
     
-    private func changeStateToStart(with duration: Int) {
-        changeStateToRunning()
+    private func presentStart(with duration: Int) {
+        presentRunning()
         resumeTimerProgressAnimation()
         startTimeProgressAnimation(with: duration)
     }
     
-    private func changeStateToResume() {
-        changeStateToRunning()
+    private func presentResume() {
+        presentRunning()
         resumeTimerProgressAnimation()
     }
     
-    private func changeStateToRunning() {
+    private func presentRunning() {
         startButton.isHidden = true
         timeLabel.isHidden = false
         timePickerView.isHidden = true
         minuteLabel.isHidden = true
-        viewModel?.startClockTimer()
         
         UIView.animate(withDuration: 0.5) { [weak self] in
             guard let self = self else { return }
@@ -330,15 +318,14 @@ final class DefaultFocusViewController: FocusViewController {
         }
     }
     
-    private func changeStateToPaused() {
+    private func presentPaused() {
         startButton.isHidden = true
         pauseButton.isHidden = true
         timeLabel.isHidden = false
         timePickerView.isHidden = true
         minuteLabel.isHidden = true
-        viewModel?.pauseClockTimer()
         pauseTimerProgressAnimation()
-
+        
         UIView.animate(withDuration: 0.5) { [weak self] in
             guard let self = self else { return }
             self.continueButton.isHidden = false
@@ -363,11 +350,13 @@ final class DefaultFocusViewController: FocusViewController {
                                         startAngle: CGFloat = 0,
                                         endAngle: CGFloat = 2 * CGFloat.pi) -> CAShapeLayer {
         let circleShapeLayer = CAShapeLayer()
-        let circlePath = UIBezierPath(arcCenter: .zero,
-                                      radius: FocusViewControllerSize.timerViewLength * 0.5,
-                                      startAngle: startAngle,
-                                      endAngle: endAngle,
-                                      clockwise: true)
+        let circlePath = UIBezierPath(
+            arcCenter: .zero,
+            radius: FocusViewControllerSize.timerViewLength * 0.5,
+            startAngle: startAngle,
+            endAngle: endAngle,
+            clockwise: true
+        )
         circleShapeLayer.path = circlePath.cgPath
         circleShapeLayer.strokeColor = strokeColor.cgColor
         circleShapeLayer.lineCap = CAShapeLayerLineCap.round
@@ -414,7 +403,9 @@ extension DefaultFocusViewController: UIPickerViewDelegate {
     }
     
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        guard let minuteInfo = viewModel?.focusTimeList[row] else { return UILabel() }
+        guard let minuteInfo = viewModel?.focusTimeList[row] else {
+            return UILabel()
+        }
         timePickerView.subviews.forEach {
             $0.backgroundColor = .clear
         }
@@ -437,7 +428,7 @@ extension DefaultFocusViewController: UIPickerViewDataSource {
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
-     
+    
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         return viewModel?.focusTimeList.count ?? 0
     }

--- a/JipJung/JipJung/UI/Home/Focus/Views/FocusButtons.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/FocusButtons.swift
@@ -1,0 +1,95 @@
+//
+//  FocusButtons.swift
+//  JipJung
+//
+//  Created by turu on 2021/11/30.
+//
+
+import UIKit
+
+final class FocusStartButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure() {
+        tintColor = .gray
+        let playImage = UIImage(systemName: "play.fill")?.withRenderingMode(.alwaysTemplate)
+        setImage(playImage, for: .normal)
+        imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 12)
+        setTitle("Start", for: .normal)
+        titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
+        titleEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
+        setTitleColor(UIColor.gray, for: .normal)
+        layer.cornerRadius = 25
+        backgroundColor = .white
+    }
+}
+
+final class FocusContinueButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure() {
+        tintColor = .gray
+        setTitle("Continue", for: .normal)
+        titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
+        titleLabel?.textAlignment = .center
+        setTitleColor(UIColor.gray, for: .normal)
+        layer.cornerRadius = 25
+        backgroundColor = .white
+    }
+}
+
+final class FocusPauseButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure() {
+        setTitle("Pause", for: .normal)
+        titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
+        setTitleColor(UIColor.white, for: .normal)
+        layer.cornerRadius = 25
+        backgroundColor = .gray
+        layer.borderColor = UIColor.white.cgColor
+        layer.borderWidth = 2
+    }
+}
+
+final class FocusExitButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure() {
+        setTitle("Exit", for: .normal)
+        titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
+        setTitleColor(UIColor.white, for: .normal)
+        layer.cornerRadius = 25
+        backgroundColor = .gray
+        layer.borderColor = UIColor.white.cgColor
+        layer.borderWidth = 2
+    }
+}

--- a/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
@@ -74,7 +74,6 @@ final class InfinityFocusViewController: FocusViewController {
             if $0 {
                 self?.cometAnimationLayer.add(CycleAnimation(), forKey: nil)
             }
-            print(self?.cometAnimationLayer.sublayers)
         }
     }
     
@@ -155,11 +154,13 @@ final class InfinityFocusViewController: FocusViewController {
                 guard let self = self else { return }
                 switch $0 {
                 case .ready:
-                    self.changeStateToReady()
+                    self.presentReady()
                 case .running(let isContinue):
-                    self.changeStateToRunning()
+                    self.viewModel?.startClockTimer()
+                    self.presentRunning()
                 case .paused:
-                    self.changeStateToPaused()
+                    self.viewModel?.pauseClockTimer()
+                    self.presentPaused()
                 }
             })
             .disposed(by: disposeBag)
@@ -188,7 +189,7 @@ final class InfinityFocusViewController: FocusViewController {
         exitButton.rx.tap
             .bind { [weak self] in
                 guard let self = self else { return }
-                self.alertNotification()
+                self.viewModel?.alertNotification()
                 self.viewModel?.changeTimerState(to: .ready)
                 self.viewModel?.resetClockTimer()
                 self.viewModel?.saveFocusRecord()
@@ -204,20 +205,7 @@ final class InfinityFocusViewController: FocusViewController {
             .disposed(by: disposeBag)
     }
     
-    private func alertNotification() {
-        guard let clockTime = self.viewModel?.clockTime.value else {
-            return
-        }
-        let happyEmojis = ["☺️", "😘", "😍", "🥳", "🤩"]
-        let minuteString = clockTime / 60 == 0 ? "" : "\(clockTime / 60)분 "
-        let secondString = clockTime % 60 == 0 ? "" : "\(clockTime % 60)초 "
-        let message = minuteString + secondString + "집중하셨어요!" + (happyEmojis.randomElement() ?? "")
-        PushNotificationMananger.shared.presentFocusStopNotification(title: .focusFinish,
-                                                                     body: message)
-        FeedbackGenerator.shared.impactOccurred()
-    }
-    
-    private func changeStateToReady() {
+    private func presentReady() {
         pauseButton.isHidden = true
         timeLabel.text = 0.digitalClockFormatted
         removePulseAnimation()
@@ -243,9 +231,8 @@ final class InfinityFocusViewController: FocusViewController {
         }
     }
     
-    private func changeStateToRunning() {
+    private func presentRunning() {
         startButton.isHidden = true
-        viewModel?.startClockTimer()
         
         UIView.animate(withDuration: 0.5) { [weak self] in
             guard let self = self else { return }
@@ -268,10 +255,9 @@ final class InfinityFocusViewController: FocusViewController {
         }
     }
     
-    private func changeStateToPaused() {
+    private func presentPaused() {
         startButton.isHidden = true
         pauseButton.isHidden = true
-        viewModel?.pauseClockTimer()
 
         UIView.animate(withDuration: 0.5) { [weak self] in
             guard let self = self else { return }
@@ -297,11 +283,13 @@ final class InfinityFocusViewController: FocusViewController {
                                         startAngle: CGFloat = 0,
                                         endAngle: CGFloat = 2 * CGFloat.pi) -> CAShapeLayer {
         let circleShapeLayer = CAShapeLayer()
-        let circlePath = UIBezierPath(arcCenter: .zero,
-                                      radius: FocusViewControllerSize.timerViewLength * 0.5,
-                                      startAngle: startAngle,
-                                      endAngle: endAngle,
-                                      clockwise: true)
+        let circlePath = UIBezierPath(
+            arcCenter: .zero,
+            radius: FocusViewControllerSize.timerViewLength * 0.5,
+            startAngle: startAngle,
+            endAngle: endAngle,
+            clockwise: true
+        )
         circleShapeLayer.path = circlePath.cgPath
         circleShapeLayer.strokeColor = strokeColor.cgColor
         circleShapeLayer.lineCap = CAShapeLayerLineCap.round
@@ -321,11 +309,13 @@ final class InfinityFocusViewController: FocusViewController {
     
     private func createCometCircleShapeLayer(strokeColor: UIColor, lineWidth: CGFloat) -> CALayer {
         let circleShapeLayer = CAShapeLayer()
-        let circlePath = UIBezierPath(arcCenter: .zero,
-                                      radius: FocusViewControllerSize.timerViewLength * 0.5,
-                                      startAngle: 0,
-                                      endAngle: 2 * CGFloat.pi,
-                                      clockwise: true)
+        let circlePath = UIBezierPath(
+            arcCenter: .zero,
+            radius: FocusViewControllerSize.timerViewLength * 0.5,
+            startAngle: 0,
+            endAngle: 2 * CGFloat.pi,
+            clockwise: true
+        )
         
         circleShapeLayer.path = circlePath.cgPath
         circleShapeLayer.strokeColor = UIColor.red.cgColor

--- a/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/InfinityFocusViewController.swift
@@ -42,55 +42,10 @@ final class InfinityFocusViewController: FocusViewController {
     
     private let pulseGroupLayer = CALayer()
     
-    private lazy var startButton: UIButton = {
-        let startButton = UIButton()
-        startButton.tintColor = .gray
-        let playImage = UIImage(systemName: "play.fill")?.withRenderingMode(.alwaysTemplate)
-        startButton.setImage(playImage, for: .normal)
-        startButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 12)
-        startButton.setTitle("Start", for: .normal)
-        startButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        startButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
-        startButton.setTitleColor(UIColor.gray, for: .normal)
-        startButton.layer.cornerRadius = 25
-        startButton.backgroundColor = .white
-        return startButton
-    }()
-    
-    private lazy var pauseButton: UIButton = {
-        let pauseButton = UIButton()
-        pauseButton.setTitle("Pause", for: .normal)
-        pauseButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
-        pauseButton.setTitleColor(UIColor.white, for: .normal)
-        pauseButton.layer.cornerRadius = 25
-        pauseButton.backgroundColor = .gray
-        pauseButton.layer.borderColor = UIColor.white.cgColor
-        pauseButton.layer.borderWidth = 2
-        return pauseButton
-    }()
-    
-    private lazy var continueButton: UIButton = {
-        let continueButton = UIButton()
-        continueButton.tintColor = .gray
-        continueButton.setTitle("Continue", for: .normal)
-        continueButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        continueButton.setTitleColor(UIColor.gray, for: .normal)
-        continueButton.layer.cornerRadius = 25
-        continueButton.backgroundColor = .white
-        return continueButton
-    }()
-    
-    private lazy var exitButton: UIButton = {
-        let exitButton = UIButton()
-        exitButton.setTitle("Exit", for: .normal)
-        exitButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
-        exitButton.setTitleColor(UIColor.white, for: .normal)
-        exitButton.layer.cornerRadius = 25
-        exitButton.backgroundColor = .gray
-        exitButton.layer.borderColor = UIColor.white.cgColor
-        exitButton.layer.borderWidth = 2
-        return exitButton
-    }()
+    private let startButton = FocusStartButton()
+    private let pauseButton = FocusPauseButton()
+    private let continueButton = FocusContinueButton()
+    private let exitButton = FocusExitButton()
     
     // MARK: - Private Variables
     

--- a/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
+++ b/JipJung/JipJung/UI/Home/Focus/Views/PomodoroFocusViewController.swift
@@ -72,55 +72,10 @@ final class PomodoroFocusViewController: FocusViewController {
     
     private let pulseGroupLayer = CALayer()
     
-    private lazy var startButton: UIButton = {
-        let startButton = UIButton()
-        startButton.tintColor = .gray
-        let playImage = UIImage(systemName: "play.fill")?.withRenderingMode(.alwaysTemplate)
-        startButton.setImage(playImage, for: .normal)
-        startButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 12)
-        startButton.setTitle("Start", for: .normal)
-        startButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        startButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
-        startButton.setTitleColor(UIColor.gray, for: .normal)
-        startButton.layer.cornerRadius = 25
-        startButton.backgroundColor = .white
-        return startButton
-    }()
-    
-    private lazy var pauseButton: UIButton = {
-        let pauseButton = UIButton()
-        pauseButton.setTitle("Pause", for: .normal)
-        pauseButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
-        pauseButton.setTitleColor(UIColor.white, for: .normal)
-        pauseButton.layer.cornerRadius = 25
-        pauseButton.backgroundColor = .gray
-        pauseButton.layer.borderColor = UIColor.white.cgColor
-        pauseButton.layer.borderWidth = 2
-        return pauseButton
-    }()
-    
-    private lazy var continueButton: UIButton = {
-        let continueButton = UIButton()
-        continueButton.tintColor = .gray
-        continueButton.setTitle("Continue", for: .normal)
-        continueButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
-        continueButton.setTitleColor(UIColor.gray, for: .normal)
-        continueButton.layer.cornerRadius = 25
-        continueButton.backgroundColor = .white
-        return continueButton
-    }()
-    
-    private lazy var exitButton: UIButton = {
-        let exitButton = UIButton()
-        exitButton.setTitle("Exit", for: .normal)
-        exitButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
-        exitButton.setTitleColor(UIColor.white, for: .normal)
-        exitButton.layer.cornerRadius = 25
-        exitButton.backgroundColor = .gray
-        exitButton.layer.borderColor = UIColor.white.cgColor
-        exitButton.layer.borderWidth = 2
-        return exitButton
-    }()
+    private let startButton = FocusStartButton()
+    private let pauseButton = FocusPauseButton()
+    private let continueButton = FocusContinueButton()
+    private let exitButton = FocusExitButton()
     
     // MARK: - Private Variables
     


### PR DESCRIPTION
# 작업 내용
- 공통으로 사용하는 뷰 분리(버튼)
- 각 focus별 ViewController에서 상태 변경 코드와 뷰 코드가 섞여있는 부분 분리
- ViewController에서 불필요한 함수를 ViewModel로 이동
- 언급했던 바인딩쪽 코드 리팩토링은 아직 하지않았습니다.
# 연관된 이슈
close #177 