### PR TITLE
🐛 아이폰 12 mini등에서 명언 설명이 짤리는 버그 해결

### DIFF
--- a/JipJung/JipJung/UI/Sound/Views/MusicPlayerMaximView.swift
+++ b/JipJung/JipJung/UI/Sound/Views/MusicPlayerMaximView.swift
@@ -12,24 +12,20 @@ import SnapKit
 class MusicPlayerMaximView: UIView {
     let maximLabel: UILabel = {
         let label = UILabel()
-        let words = """
+        let text = """
         At night,
         The moon draws faint tides from ear to ear.
         """
         label.font = .systemFont(ofSize: 14, weight: .semibold)
         label.numberOfLines = 0
         label.textColor = .white
+        label.text = text
+        label.setLineSpacing(lineSpacing: 24)
         
-        let attrString = NSMutableAttributedString(string: words)
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 24
-        attrString.addAttribute(
-            NSAttributedString.Key.paragraphStyle,
-            value: paragraphStyle,
-            range: NSMakeRange(0, attrString.length)
-        )
-        label.attributedText = attrString
-        
+        label.lineBreakMode = .byWordWrapping
+        if #available(iOS 14.0, *) {
+            label.lineBreakStrategy = .hangulWordPriority
+        }
         return label
     }()
     
@@ -59,7 +55,6 @@ class MusicPlayerMaximView: UIView {
         maximLabel.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.center.equalToSuperview()
-            $0.height.equalTo(maximLabel.intrinsicContentSize.height)
         }
         
         speakerNameLabel.snp.makeConstraints {


### PR DESCRIPTION
# 작업 내용
- iOS14 버전 이후에는 단어단위로 올라갈 수 있도록 개선하였습니다.

# 관련된 이슈 번호
#195 